### PR TITLE
feat: add download all zip button in complete section

### DIFF
--- a/src/components/ConverterPage.tsx
+++ b/src/components/ConverterPage.tsx
@@ -5,6 +5,7 @@ import { Options } from './Options'
 import { Progress } from './Progress'
 import { Results } from './Results'
 import { Viewer } from './Viewer'
+import JSZip from 'jszip'
 import { convertToXtc } from '../lib/converter'
 import type { ConversionOptions } from '../lib/conversion/types'
 import { recordConversion } from '../lib/api'
@@ -19,6 +20,45 @@ interface ConverterPageProps {
 
 const MAX_FALLBACK_PREVIEW_PAGES = 200
 const PROGRESS_UPDATE_INTERVAL_MS = 120
+
+function formatZipTimestamp(date: Date): string {
+  const year = date.getFullYear()
+  const month = String(date.getMonth() + 1).padStart(2, '0')
+  const day = String(date.getDate()).padStart(2, '0')
+  const hours = String(date.getHours()).padStart(2, '0')
+  const minutes = String(date.getMinutes()).padStart(2, '0')
+  const seconds = String(date.getSeconds()).padStart(2, '0')
+  return `${year}${month}${day}-${hours}${minutes}${seconds}`
+}
+
+function normalizeZipEntryName(name: string): string {
+  const trimmed = name.trim()
+  if (!trimmed) return 'conversion.xtc'
+  const baseName = trimmed.split(/[\\/]/).pop()
+  return baseName && baseName.length > 0 ? baseName : 'conversion.xtc'
+}
+
+function getUniqueZipEntryName(fileName: string, usedNames: Set<string>): string {
+  const normalized = fileName.toLowerCase()
+  if (!usedNames.has(normalized)) {
+    usedNames.add(normalized)
+    return fileName
+  }
+
+  const dotIndex = fileName.lastIndexOf('.')
+  const base = dotIndex > 0 ? fileName.slice(0, dotIndex) : fileName
+  const ext = dotIndex > 0 ? fileName.slice(dotIndex) : ''
+
+  let suffix = 2
+  let candidate = `${base} (${suffix})${ext}`
+  while (usedNames.has(candidate.toLowerCase())) {
+    suffix++
+    candidate = `${base} (${suffix})${ext}`
+  }
+
+  usedNames.add(candidate.toLowerCase())
+  return candidate
+}
 
 export function ConverterPage({ fileType, notice }: ConverterPageProps) {
   const [selectedFiles, setSelectedFiles] = useState<File[]>([])
@@ -268,6 +308,52 @@ export function ConverterPage({ fileType, notice }: ConverterPageProps) {
     }
   }, [downloadResult])
 
+  const handleDownloadAll = useCallback(async () => {
+    const successfulResults = [...recoveredResults, ...results].filter(result => !result.error)
+    if (successfulResults.length === 0) {
+      return
+    }
+
+    try {
+      const zip = new JSZip()
+      const usedNames = new Set<string>()
+      let addedCount = 0
+
+      for (const result of successfulResults) {
+        const data = await getResultData(result)
+        if (!data || data.byteLength === 0) {
+          console.warn(`Skipping ${result.name}: no data found`)
+          continue
+        }
+
+        const entryName = getUniqueZipEntryName(normalizeZipEntryName(result.name), usedNames)
+        zip.file(entryName, data)
+        addedCount++
+      }
+
+      if (addedCount === 0) {
+        console.warn('No valid files found for ZIP download')
+        return
+      }
+
+      const zipBlob = await zip.generateAsync({
+        type: 'blob',
+        compression: 'DEFLATE',
+      })
+      const archiveName = `xtcjs-conversions-${formatZipTimestamp(new Date())}.zip`
+      const url = URL.createObjectURL(zipBlob)
+      const anchor = document.createElement('a')
+      anchor.href = url
+      anchor.download = archiveName
+      document.body.appendChild(anchor)
+      anchor.click()
+      document.body.removeChild(anchor)
+      URL.revokeObjectURL(url)
+    } catch (err) {
+      console.error('Download all failed:', err)
+    }
+  }, [recoveredResults, results, getResultData])
+
   const handleClearResults = useCallback(async () => {
     await clearSession()
     previewCacheRef.current.clear()
@@ -286,6 +372,7 @@ export function ConverterPage({ fileType, notice }: ConverterPageProps) {
 
   // Combine current and recovered results for display
   const allResults = [...recoveredResults, ...results]
+  const downloadableCount = allResults.filter(result => !result.error).length
 
   return (
     <>
@@ -338,6 +425,8 @@ export function ConverterPage({ fileType, notice }: ConverterPageProps) {
       <Results
         results={allResults}
         onDownload={handleDownload}
+        onDownloadAll={downloadableCount > 0 ? handleDownloadAll : undefined}
+        downloadAllCount={downloadableCount}
         onPreview={handlePreview}
         onClear={results.length > 0 ? handleClearResults : undefined}
       />

--- a/src/components/Results.tsx
+++ b/src/components/Results.tsx
@@ -5,10 +5,19 @@ interface ResultsProps {
   results: StoredResult[]
   onDownload: (result: StoredResult) => void | Promise<void>
   onPreview: (result: StoredResult) => void | Promise<void>
+  onDownloadAll?: () => void | Promise<void>
+  downloadAllCount?: number
   onClear?: () => void | Promise<void>
 }
 
-export function Results({ results, onDownload, onPreview, onClear }: ResultsProps) {
+export function Results({
+  results,
+  onDownload,
+  onPreview,
+  onDownloadAll,
+  downloadAllCount = 0,
+  onClear,
+}: ResultsProps) {
   if (results.length === 0) {
     return null
   }
@@ -17,10 +26,19 @@ export function Results({ results, onDownload, onPreview, onClear }: ResultsProp
     <section className="results-section">
       <div className="section-header">
         <h2>Complete</h2>
-        {onClear && (
-          <button className="btn-clear-results" onClick={onClear}>
-            Clear Results
-          </button>
+        {(onDownloadAll || onClear) && (
+          <div className="results-header-actions">
+            {onDownloadAll && downloadAllCount > 0 && (
+              <button className="btn-download-results-zip" onClick={onDownloadAll}>
+                Download All ({downloadAllCount})
+              </button>
+            )}
+            {onClear && (
+              <button className="btn-clear-results" onClick={onClear}>
+                Clear Results
+              </button>
+            )}
+          </div>
         )}
       </div>
       <div className="results-grid">

--- a/src/styles/components.css
+++ b/src/styles/components.css
@@ -1031,6 +1031,35 @@
   color: var(--accent);
 }
 
+.results-header-actions {
+  margin-left: auto;
+  display: flex;
+  align-items: center;
+  gap: var(--space-xs);
+  flex-wrap: wrap;
+  justify-content: flex-end;
+}
+
+.results-header-actions .btn-clear-results {
+  margin-left: 0;
+}
+
+.btn-download-results-zip {
+  padding: var(--space-xs) var(--space-sm);
+  background: var(--ink);
+  border: 1px solid var(--ink);
+  color: var(--paper);
+  font-family: var(--font-mono);
+  font-size: 0.7rem;
+  cursor: pointer;
+  transition: all 0.15s;
+}
+
+.btn-download-results-zip:hover {
+  background: var(--accent);
+  border-color: var(--accent);
+}
+
 /* Metadata editor */
 .metadata-status {
   margin: var(--space-md) 0;


### PR DESCRIPTION
## Summary
- add a Download All action in the Complete section header next to Clear Results
- bundle all visible successful converted files (current + recovered) into a single ZIP
- keep per-file download behavior unchanged
 
## Validation
- bun run build

 
Fixes #16