### PR TITLE
Add page overview option for split manga and PDF pages

### DIFF
--- a/src/components/ConverterPage.tsx
+++ b/src/components/ConverterPage.tsx
@@ -124,6 +124,7 @@ export function ConverterPage({ fileType, notice }: ConverterPageProps) {
   const [options, setOptions] = useState<ConversionOptions>({
     device: 'X4',
     splitMode: (fileType === 'image' || fileType === 'video') ? 'nosplit' : 'overlap',
+    pageOverview: 'none',
     dithering: fileType === 'pdf' ? 'atkinson' : 'floyd',
     contrast: fileType === 'pdf' ? 8 : 4,
     horizontalMargin: 0,

--- a/src/components/Options.tsx
+++ b/src/components/Options.tsx
@@ -12,6 +12,9 @@ export function Options({ options, onChange, fileType = 'cbz' }: OptionsProps) {
   const isImageMode = fileType === 'image'
   const isVideoMode = fileType === 'video'
   const supportsSplit = !isImageMode && !isVideoMode && options.orientation === 'landscape'
+  const showPageOverview = supportsSplit &&
+    options.splitMode !== 'nosplit' &&
+    (fileType === 'cbz' || fileType === 'pdf')
 
   return (
     <div className="options-stack">
@@ -118,11 +121,26 @@ export function Options({ options, onChange, fileType = 'cbz' }: OptionsProps) {
             <select
               id="splitMode"
               value={options.splitMode}
-              onChange={(e) => onChange({ ...options, splitMode: e.target.value })}
+              onChange={(e) => onChange({ ...options, splitMode: e.target.value as ConversionOptions['splitMode'] })}
             >
               <option value="overlap">Overlapping thirds</option>
               <option value="split">Split in half</option>
               <option value="nosplit">No split</option>
+            </select>
+          </div>
+        )}
+
+        {showPageOverview && (
+          <div className="option">
+            <label htmlFor="pageOverview">Page Overview</label>
+            <select
+              id="pageOverview"
+              value={options.pageOverview}
+              onChange={(e) => onChange({ ...options, pageOverview: e.target.value as ConversionOptions['pageOverview'] })}
+            >
+              <option value="none">None</option>
+              <option value="portrait">Portrait</option>
+              <option value="landscape">Landscape</option>
             </select>
           </div>
         )}

--- a/src/lib/conversion/types.ts
+++ b/src/lib/conversion/types.ts
@@ -1,6 +1,10 @@
+export type SplitMode = 'overlap' | 'split' | 'nosplit'
+export type PageOverviewMode = 'none' | 'portrait' | 'landscape'
+
 export interface ConversionOptions {
   device: 'X4' | 'X3'
-  splitMode: string
+  splitMode: SplitMode
+  pageOverview: PageOverviewMode
   dithering: string
   contrast: number
   horizontalMargin: number

--- a/src/lib/converter.ts
+++ b/src/lib/converter.ts
@@ -40,6 +40,26 @@ interface CropRect {
   height: number
 }
 
+function buildOverviewPage(
+  canvas: HTMLCanvasElement,
+  pageNum: number,
+  targetWidth: number,
+  targetHeight: number,
+  options: ConversionOptions,
+  landscapeRotation: number
+): ProcessedPage {
+  const overviewCanvas = options.pageOverview === 'portrait'
+    ? resizeWithPadding(canvas, 255, targetWidth, targetHeight)
+    : resizeWithPadding(rotateCanvas(canvas, landscapeRotation), 255, targetWidth, targetHeight)
+
+  applyDithering(overviewCanvas.getContext('2d')!, targetWidth, targetHeight, options.dithering)
+
+  return {
+    name: `${String(pageNum).padStart(4, '0')}_1_overview_${options.pageOverview}.png`,
+    canvas: overviewCanvas
+  }
+}
+
 function clampMarginPercent(value: number): number {
   if (!Number.isFinite(value)) return 0
   return Math.max(0, Math.min(20, value))
@@ -823,6 +843,10 @@ function processCanvasAsImage(
   const shouldSplit = width < height && options.splitMode !== 'nosplit'
 
   if (shouldSplit) {
+    if (options.pageOverview !== 'none') {
+      results.push(buildOverviewPage(canvas, pageNum, targetWidth, targetHeight, options, landscapeRotation))
+    }
+
     if (options.splitMode === 'overlap') {
       const segments = calculateOverlapSegments(width, height)
       segments.forEach((seg, idx) => {
@@ -949,6 +973,10 @@ function processLoadedImage(
   const shouldSplit = width < height && options.splitMode !== 'nosplit'
 
   if (shouldSplit) {
+    if (options.pageOverview !== 'none') {
+      results.push(buildOverviewPage(canvas, pageNum, targetWidth, targetHeight, options, landscapeRotation))
+    }
+
     if (options.splitMode === 'overlap') {
       const segments = calculateOverlapSegments(width, height)
       segments.forEach((seg, idx) => {

--- a/src/lib/workers/convert-page.worker.ts
+++ b/src/lib/workers/convert-page.worker.ts
@@ -38,6 +38,10 @@ const DEVICE_DIMENSIONS = {
   X3: { width: 528, height: 792 }
 } as const
 
+function getPageName(pageNum: number, suffix: string): string {
+  return `${String(pageNum).padStart(4, '0')}_${suffix}.png`
+}
+
 function getTargetDimensions(options: ConversionOptions): { width: number; height: number } {
   return DEVICE_DIMENSIONS[options.device] ?? DEVICE_DIMENSIONS.X4
 }
@@ -150,6 +154,35 @@ async function buildWorkerPage(
   }
 }
 
+async function buildOverviewWorkerPage(
+  baseCanvas: OffscreenCanvas,
+  pageNum: number,
+  options: ConversionOptions,
+  landscapeRotation: number,
+  includePreview: boolean,
+  targetWidth: number,
+  targetHeight: number
+): Promise<WorkerPageResult> {
+  const overviewCanvas = options.pageOverview === 'portrait'
+    ? resizeWithPadding(baseCanvas, 255, targetWidth, targetHeight)
+    : resizeWithPadding(rotateCanvas(baseCanvas, landscapeRotation), 255, targetWidth, targetHeight)
+
+  applyDithering(
+    asCanvas2d(overviewCanvas.getContext('2d', { alpha: false })!),
+    targetWidth,
+    targetHeight,
+    options.dithering
+  )
+
+  return buildWorkerPage(
+    getPageName(pageNum, `1_overview_${options.pageOverview}`),
+    overviewCanvas,
+    includePreview,
+    targetWidth,
+    targetHeight
+  )
+}
+
 async function processBitmap(
   source: ImageBitmap,
   pageNum: number,
@@ -188,7 +221,7 @@ async function processBitmap(
       options.dithering
     )
     results.push(await buildWorkerPage(
-      `${String(pageNum).padStart(4, '0')}_0_page.png`,
+      getPageName(pageNum, '0_page'),
       finalCanvas,
       includePreview,
       targetWidth,
@@ -202,6 +235,19 @@ async function processBitmap(
   let previewAssigned = false
 
   if (shouldSplit) {
+    if (options.pageOverview !== 'none') {
+      results.push(await buildOverviewWorkerPage(
+        baseCanvas,
+        pageNum,
+        options,
+        landscapeRotation,
+        includePreview && !previewAssigned,
+        targetWidth,
+        targetHeight
+      ))
+      previewAssigned = true
+    }
+
     if (options.splitMode === 'overlap') {
       const segments = calculateOverlapSegments(width, height)
       for (let idx = 0; idx < segments.length; idx++) {
@@ -217,7 +263,7 @@ async function processBitmap(
         )
 
         results.push(await buildWorkerPage(
-          `${String(pageNum).padStart(4, '0')}_3_${letter}.png`,
+          getPageName(pageNum, `3_${letter}`),
           finalCanvas,
           includePreview && !previewAssigned,
           targetWidth,
@@ -237,7 +283,7 @@ async function processBitmap(
         options.dithering
       )
       results.push(await buildWorkerPage(
-        `${String(pageNum).padStart(4, '0')}_2_a.png`,
+        getPageName(pageNum, '2_a'),
         topFinal,
         includePreview && !previewAssigned,
         targetWidth,
@@ -254,7 +300,7 @@ async function processBitmap(
         options.dithering
       )
       results.push(await buildWorkerPage(
-        `${String(pageNum).padStart(4, '0')}_2_b.png`,
+        getPageName(pageNum, '2_b'),
         bottomFinal,
         includePreview && !previewAssigned,
         targetWidth,
@@ -271,7 +317,7 @@ async function processBitmap(
       options.dithering
     )
     results.push(await buildWorkerPage(
-      `${String(pageNum).padStart(4, '0')}_0_spread.png`,
+      getPageName(pageNum, '0_spread'),
       finalCanvas,
       includePreview,
       targetWidth,


### PR DESCRIPTION
## Summary
- add a Page Overview setting after Page Split for manga and PDF conversions when split mode is active
- prepend an optional full-page overview before the generated split pages without changing the existing split logic
- keep the main-thread and worker conversion pipelines in sync for identical output ordering

## Testing
- npm run build