### PR TITLE
Add XTCH output for image conversions

### DIFF
--- a/src/components/ConverterPage.tsx
+++ b/src/components/ConverterPage.tsx
@@ -126,6 +126,7 @@ export function ConverterPage({ fileType, notice }: ConverterPageProps) {
     splitMode: (fileType === 'image' || fileType === 'video') ? 'nosplit' : 'overlap',
     pageOverview: 'none',
     dithering: fileType === 'pdf' ? 'atkinson' : 'floyd',
+    is2bit: false,
     contrast: fileType === 'pdf' ? 8 : 4,
     horizontalMargin: 0,
     verticalMargin: 0,
@@ -240,9 +241,10 @@ export function ConverterPage({ fileType, notice }: ConverterPageProps) {
         recordConversion(fileType === 'image' || fileType === 'video' ? 'cbz' : fileType).catch(() => {})
       } catch (err) {
         console.error(`Error converting ${file.name}:`, err)
+        const fallbackExtension = fileType === 'image' && options.is2bit ? '.xtch' : '.xtc'
         // Store error result
         await addResult({
-          name: file.name.replace(/\.[^/.]+$/i, '.xtc'),
+          name: file.name.replace(/\.[^/.]+$/i, fallbackExtension),
           error: normalizeUserErrorMessage(err instanceof Error ? err.message : 'Unknown error'),
         })
       }

--- a/src/components/Options.tsx
+++ b/src/components/Options.tsx
@@ -97,6 +97,20 @@ export function Options({ options, onChange, fileType = 'cbz' }: OptionsProps) {
           </div>
         )}
 
+        {isImageMode && (
+          <div className="option option-checkbox">
+            <label htmlFor="is2bit" className="checkbox-label">
+              <input
+                type="checkbox"
+                id="is2bit"
+                checked={options.is2bit}
+                onChange={(e) => onChange({ ...options, is2bit: e.target.checked })}
+              />
+              <span>Use XTCH 2-bit grayscale output</span>
+            </label>
+          </div>
+        )}
+
         {isVideoMode && (
           <div className="option">
             <label htmlFor="videoFps">Video FPS</label>

--- a/src/lib/conversion/types.ts
+++ b/src/lib/conversion/types.ts
@@ -6,6 +6,7 @@ export interface ConversionOptions {
   splitMode: SplitMode
   pageOverview: PageOverviewMode
   dithering: string
+  is2bit: boolean
   contrast: number
   horizontalMargin: number
   verticalMargin: number

--- a/src/lib/converter.ts
+++ b/src/lib/converter.ts
@@ -6,7 +6,7 @@ import unrarWasm from 'node-unrar-js/esm/js/unrar.wasm?url'
 import { applyDithering } from './processing/dithering'
 import { toGrayscale, applyContrast, calculateOverlapSegments } from './processing/image'
 import { rotateCanvas, extractAndRotate, resizeWithPadding, getTargetDimensions } from './processing/canvas'
-import { imageDataToXtg } from './processing/xtg'
+import { imageDataToXtg, imageDataToXth } from './processing/xtg'
 import { buildXtcFromXtgPages } from './xtc-format'
 import { extractPdfMetadata } from './metadata/pdf-outline'
 import { parseComicInfo } from './metadata/comicinfo'
@@ -248,6 +248,15 @@ function encodeCanvasPage(page: ProcessedPage): EncodedPage {
   return {
     name: page.name,
     xtg: imageDataToXtg(imageData)
+  }
+}
+
+function encodeImageCanvasPage(page: ProcessedPage, is2bit: boolean): EncodedPage {
+  const ctx = page.canvas.getContext('2d')!
+  const imageData = ctx.getImageData(0, 0, page.canvas.width, page.canvas.height)
+  return {
+    name: page.name,
+    xtg: is2bit ? imageDataToXth(imageData) : imageDataToXtg(imageData)
   }
 }
 
@@ -565,6 +574,13 @@ function getOutputName(fileName: string): string {
   return `${fileName.slice(0, dot)}.xtc`
 }
 
+function getImageOutputName(fileName: string, is2bit: boolean): string {
+  const dot = fileName.lastIndexOf('.')
+  const extension = is2bit ? '.xtch' : '.xtc'
+  if (dot <= 0) return `${fileName}${extension}`
+  return `${fileName.slice(0, dot)}${extension}`
+}
+
 /**
  * Convert a single image file to XTC.
  */
@@ -576,15 +592,13 @@ export async function convertImageToXtc(
   const imagePages = await processImage(file, 1, {
     ...options,
     splitMode: 'nosplit'
-  })
+  }, options.is2bit)
 
   if (imagePages.length === 0) {
     throw new Error('Failed to decode image')
   }
 
-  const encodedPages = imagePages.map(encodeCanvasPage)
-  const mappingCtx = new PageMappingContext()
-  mappingCtx.addOriginalPage(1, imagePages.length)
+  const encodedPages = imagePages.map((page) => encodeImageCanvasPage(page, options.is2bit))
 
   let previewUrl: string | null = null
   const sampledPreviews: string[] = []
@@ -594,13 +608,21 @@ export async function convertImageToXtc(
   }
   onProgress(1, previewUrl)
 
-  return finalizeConversionResult(
-    getOutputName(file.name),
-    encodedPages,
-    mappingCtx,
-    { toc: [] },
-    sampledPreviews
+  encodedPages.sort((a, b) => a.name.localeCompare(b.name))
+
+  const xtcData = await buildXtcFromXtgPages(
+    encodedPages.map((page) => page.xtg),
+    { metadata: { toc: [] }, is2bit: options.is2bit }
   )
+
+  return {
+    name: getImageOutputName(file.name, options.is2bit),
+    data: xtcData,
+    size: xtcData.byteLength,
+    pageCount: encodedPages.length,
+    pageImages: sampledPreviews,
+    previewMode: 'sparse'
+  }
 }
 
 async function waitForVideoMetadata(video: HTMLVideoElement): Promise<void> {
@@ -899,7 +921,8 @@ function processCanvasAsImage(
 async function processImage(
   imgBlob: Blob,
   pageNum: number,
-  options: ConversionOptions
+  options: ConversionOptions,
+  is2bit = false
 ): Promise<ProcessedPage[]> {
   return new Promise((resolve) => {
     const img = new Image()
@@ -907,7 +930,7 @@ async function processImage(
 
     img.onload = () => {
       URL.revokeObjectURL(objectUrl)
-      const pages = processLoadedImage(img, pageNum, options)
+      const pages = processLoadedImage(img, pageNum, options, is2bit)
       resolve(pages)
     }
     img.onerror = () => {
@@ -925,7 +948,8 @@ async function processImage(
 function processLoadedImage(
   img: HTMLImageElement,
   pageNum: number,
-  options: ConversionOptions
+  options: ConversionOptions,
+  is2bit = false
 ): ProcessedPage[] {
   const { width: targetWidth, height: targetHeight } = getOutputDimensions(options)
   const results: ProcessedPage[] = []
@@ -960,7 +984,7 @@ function processLoadedImage(
       options.imageMode,
       255
     )
-    applyDithering(finalCanvas.getContext('2d')!, targetWidth, targetHeight, options.dithering)
+    applyDithering(finalCanvas.getContext('2d')!, targetWidth, targetHeight, options.dithering, is2bit)
 
     results.push({
       name: `${String(pageNum).padStart(4, '0')}_0_page.png`,
@@ -983,7 +1007,7 @@ function processLoadedImage(
         const letter = String.fromCharCode(97 + idx)
         const pageCanvas = extractAndRotate(canvas, seg.x, seg.y, seg.w, seg.h, landscapeRotation)
         const finalCanvas = resizeWithPadding(pageCanvas, 255, targetWidth, targetHeight)
-        applyDithering(finalCanvas.getContext('2d')!, targetWidth, targetHeight, options.dithering)
+        applyDithering(finalCanvas.getContext('2d')!, targetWidth, targetHeight, options.dithering, is2bit)
 
         results.push({
           name: `${String(pageNum).padStart(4, '0')}_3_${letter}.png`,
@@ -995,7 +1019,7 @@ function processLoadedImage(
 
       const topCanvas = extractAndRotate(canvas, 0, 0, width, halfHeight, landscapeRotation)
       const topFinal = resizeWithPadding(topCanvas, 255, targetWidth, targetHeight)
-      applyDithering(topFinal.getContext('2d')!, targetWidth, targetHeight, options.dithering)
+      applyDithering(topFinal.getContext('2d')!, targetWidth, targetHeight, options.dithering, is2bit)
       results.push({
         name: `${String(pageNum).padStart(4, '0')}_2_a.png`,
         canvas: topFinal
@@ -1003,7 +1027,7 @@ function processLoadedImage(
 
       const bottomCanvas = extractAndRotate(canvas, 0, halfHeight, width, halfHeight, landscapeRotation)
       const bottomFinal = resizeWithPadding(bottomCanvas, 255, targetWidth, targetHeight)
-      applyDithering(bottomFinal.getContext('2d')!, targetWidth, targetHeight, options.dithering)
+      applyDithering(bottomFinal.getContext('2d')!, targetWidth, targetHeight, options.dithering, is2bit)
       results.push({
         name: `${String(pageNum).padStart(4, '0')}_2_b.png`,
         canvas: bottomFinal
@@ -1012,7 +1036,7 @@ function processLoadedImage(
   } else {
     const rotatedCanvas = rotateCanvas(canvas, landscapeRotation)
     const finalCanvas = resizeWithPadding(rotatedCanvas, 255, targetWidth, targetHeight)
-    applyDithering(finalCanvas.getContext('2d')!, targetWidth, targetHeight, options.dithering)
+    applyDithering(finalCanvas.getContext('2d')!, targetWidth, targetHeight, options.dithering, is2bit)
 
     results.push({
       name: `${String(pageNum).padStart(4, '0')}_0_spread.png`,

--- a/src/lib/processing/dithering.ts
+++ b/src/lib/processing/dithering.ts
@@ -1,6 +1,16 @@
 // Dithering algorithms optimized for manga on e-ink displays
 // Each algorithm has different characteristics for handling manga art
 
+function quantizePixel(value: number, is2bit: boolean): number {
+  if (!is2bit) {
+    return value >= 128 ? 255 : 0
+  }
+  if (value < 42) return 0
+  if (value < 127) return 85
+  if (value < 212) return 170
+  return 255
+}
+
 /**
  * Applies the selected dithering algorithm to canvas
  */
@@ -8,41 +18,42 @@ export function applyDithering(
   ctx: CanvasRenderingContext2D,
   width: number,
   height: number,
-  algorithm: string
+  algorithm: string,
+  is2bit = false
 ): void {
-  const imageData = ctx.getImageData(0, 0, width, height);
-  const data = imageData.data;
+  const imageData = ctx.getImageData(0, 0, width, height)
+  const data = imageData.data
 
   switch (algorithm) {
     case 'none':
-      applyThreshold(data);
-      break;
+      applyThreshold(data, is2bit)
+      break
     case 'sierra-lite':
-      applySierraLite(data, width, height);
-      break;
+      applySierraLite(data, width, height, is2bit)
+      break
     case 'atkinson':
-      applyAtkinson(data, width, height);
-      break;
+      applyAtkinson(data, width, height, is2bit)
+      break
     case 'floyd':
-      applyFloydSteinberg(data, width, height);
-      break;
+      applyFloydSteinberg(data, width, height, is2bit)
+      break
     case 'ordered':
-      applyOrdered(data, width, height);
-      break;
+      applyOrdered(data, width, height, is2bit)
+      break
     default:
-      applyFloydSteinberg(data, width, height);
+      applyFloydSteinberg(data, width, height, is2bit)
   }
 
-  ctx.putImageData(imageData, 0, 0);
+  ctx.putImageData(imageData, 0, 0)
 }
 
 /**
  * Simple threshold - no dithering
  */
-function applyThreshold(data: Uint8ClampedArray): void {
+function applyThreshold(data: Uint8ClampedArray, is2bit: boolean): void {
   for (let i = 0; i < data.length; i += 4) {
-    const val = data[i] >= 128 ? 255 : 0;
-    data[i] = data[i + 1] = data[i + 2] = val;
+    const val = quantizePixel(data[i], is2bit)
+    data[i] = data[i + 1] = data[i + 2] = val
   }
 }
 
@@ -54,32 +65,36 @@ function applyThreshold(data: Uint8ClampedArray): void {
  *     1   1
  * Divider: 4
  */
-function applySierraLite(data: Uint8ClampedArray, width: number, height: number): void {
-  const pixels = new Float32Array(width * height);
+function applySierraLite(
+  data: Uint8ClampedArray,
+  width: number,
+  height: number,
+  is2bit: boolean
+): void {
+  const pixels = new Float32Array(width * height)
   for (let i = 0; i < pixels.length; i++) {
-    pixels[i] = data[i * 4];
+    pixels[i] = data[i * 4]
   }
 
   for (let y = 0; y < height; y++) {
     for (let x = 0; x < width; x++) {
-      const idx = y * width + x;
-      const oldPixel = pixels[idx];
-      const newPixel = oldPixel >= 128 ? 255 : 0;
-      pixels[idx] = newPixel;
-      const error = oldPixel - newPixel;
+      const idx = y * width + x
+      const oldPixel = pixels[idx]
+      const newPixel = quantizePixel(oldPixel, is2bit)
+      pixels[idx] = newPixel
+      const error = oldPixel - newPixel
 
-      // Distribute error
-      if (x + 1 < width) pixels[idx + 1] += error * 2 / 4;
+      if (x + 1 < width) pixels[idx + 1] += error * 2 / 4
       if (y + 1 < height) {
-        if (x > 0) pixels[idx + width - 1] += error * 1 / 4;
-        pixels[idx + width] += error * 1 / 4;
+        if (x > 0) pixels[idx + width - 1] += error * 1 / 4
+        pixels[idx + width] += error * 1 / 4
       }
     }
   }
 
   for (let i = 0; i < pixels.length; i++) {
-    const val = Math.max(0, Math.min(255, pixels[i]));
-    data[i * 4] = data[i * 4 + 1] = data[i * 4 + 2] = val;
+    const val = Math.max(0, Math.min(255, pixels[i]))
+    data[i * 4] = data[i * 4 + 1] = data[i * 4 + 2] = val
   }
 }
 
@@ -88,36 +103,41 @@ function applySierraLite(data: Uint8ClampedArray, width: number, height: number)
  * Creates lighter images, good for preventing dark pages
  * Only distributes 75% of error (6/8)
  */
-function applyAtkinson(data: Uint8ClampedArray, width: number, height: number): void {
-  const pixels = new Float32Array(width * height);
+function applyAtkinson(
+  data: Uint8ClampedArray,
+  width: number,
+  height: number,
+  is2bit: boolean
+): void {
+  const pixels = new Float32Array(width * height)
   for (let i = 0; i < pixels.length; i++) {
-    pixels[i] = data[i * 4];
+    pixels[i] = data[i * 4]
   }
 
   for (let y = 0; y < height; y++) {
     for (let x = 0; x < width; x++) {
-      const idx = y * width + x;
-      const oldPixel = pixels[idx];
-      const newPixel = oldPixel >= 128 ? 255 : 0;
-      pixels[idx] = newPixel;
-      const error = (oldPixel - newPixel) / 8;
+      const idx = y * width + x
+      const oldPixel = pixels[idx]
+      const newPixel = quantizePixel(oldPixel, is2bit)
+      pixels[idx] = newPixel
+      const error = (oldPixel - newPixel) / 8
 
-      if (x + 1 < width) pixels[idx + 1] += error;
-      if (x + 2 < width) pixels[idx + 2] += error;
+      if (x + 1 < width) pixels[idx + 1] += error
+      if (x + 2 < width) pixels[idx + 2] += error
       if (y + 1 < height) {
-        if (x > 0) pixels[idx + width - 1] += error;
-        pixels[idx + width] += error;
-        if (x + 1 < width) pixels[idx + width + 1] += error;
+        if (x > 0) pixels[idx + width - 1] += error
+        pixels[idx + width] += error
+        if (x + 1 < width) pixels[idx + width + 1] += error
       }
       if (y + 2 < height) {
-        pixels[idx + width * 2] += error;
+        pixels[idx + width * 2] += error
       }
     }
   }
 
   for (let i = 0; i < pixels.length; i++) {
-    const val = Math.max(0, Math.min(255, pixels[i]));
-    data[i * 4] = data[i * 4 + 1] = data[i * 4 + 2] = val;
+    const val = Math.max(0, Math.min(255, pixels[i]))
+    data[i * 4] = data[i * 4 + 1] = data[i * 4 + 2] = val
   }
 }
 
@@ -125,32 +145,37 @@ function applyAtkinson(data: Uint8ClampedArray, width: number, height: number): 
  * Floyd-Steinberg dithering
  * The classic algorithm, good balance
  */
-function applyFloydSteinberg(data: Uint8ClampedArray, width: number, height: number): void {
-  const pixels = new Float32Array(width * height);
+function applyFloydSteinberg(
+  data: Uint8ClampedArray,
+  width: number,
+  height: number,
+  is2bit: boolean
+): void {
+  const pixels = new Float32Array(width * height)
   for (let i = 0; i < pixels.length; i++) {
-    pixels[i] = data[i * 4];
+    pixels[i] = data[i * 4]
   }
 
   for (let y = 0; y < height; y++) {
     for (let x = 0; x < width; x++) {
-      const idx = y * width + x;
-      const oldPixel = pixels[idx];
-      const newPixel = oldPixel >= 128 ? 255 : 0;
-      pixels[idx] = newPixel;
-      const error = oldPixel - newPixel;
+      const idx = y * width + x
+      const oldPixel = pixels[idx]
+      const newPixel = quantizePixel(oldPixel, is2bit)
+      pixels[idx] = newPixel
+      const error = oldPixel - newPixel
 
-      if (x + 1 < width) pixels[idx + 1] += error * 7 / 16;
+      if (x + 1 < width) pixels[idx + 1] += error * 7 / 16
       if (y + 1 < height) {
-        if (x > 0) pixels[idx + width - 1] += error * 3 / 16;
-        pixels[idx + width] += error * 5 / 16;
-        if (x + 1 < width) pixels[idx + width + 1] += error * 1 / 16;
+        if (x > 0) pixels[idx + width - 1] += error * 3 / 16
+        pixels[idx + width] += error * 5 / 16
+        if (x + 1 < width) pixels[idx + width + 1] += error * 1 / 16
       }
     }
   }
 
   for (let i = 0; i < pixels.length; i++) {
-    const val = Math.max(0, Math.min(255, pixels[i]));
-    data[i * 4] = data[i * 4 + 1] = data[i * 4 + 2] = val;
+    const val = Math.max(0, Math.min(255, pixels[i]))
+    data[i * 4] = data[i * 4 + 1] = data[i * 4 + 2] = val
   }
 }
 
@@ -158,20 +183,34 @@ function applyFloydSteinberg(data: Uint8ClampedArray, width: number, height: num
  * Ordered/Bayer dithering
  * Creates regular patterns
  */
-function applyOrdered(data: Uint8ClampedArray, width: number, height: number): void {
+function applyOrdered(
+  data: Uint8ClampedArray,
+  width: number,
+  height: number,
+  is2bit: boolean
+): void {
   const bayer = [
     [0, 8, 2, 10],
     [12, 4, 14, 6],
     [3, 11, 1, 9],
     [15, 7, 13, 5]
-  ];
+  ]
 
   for (let y = 0; y < height; y++) {
     for (let x = 0; x < width; x++) {
-      const idx = (y * width + x) * 4;
-      const threshold = (bayer[y % 4][x % 4] / 16) * 255;
-      const val = data[idx] > threshold ? 255 : 0;
-      data[idx] = data[idx + 1] = data[idx + 2] = val;
+      const idx = (y * width + x) * 4
+      const matrixValue = bayer[y % 4][x % 4]
+
+      let val: number
+      if (is2bit) {
+        const adjusted = data[idx] + (((matrixValue + 0.5) / 16) - 0.5) * 64
+        val = quantizePixel(Math.max(0, Math.min(255, adjusted)), true)
+      } else {
+        const threshold = (matrixValue / 16) * 255
+        val = data[idx] > threshold ? 255 : 0
+      }
+
+      data[idx] = data[idx + 1] = data[idx + 2] = val
     }
   }
 }

--- a/src/lib/processing/xtg.ts
+++ b/src/lib/processing/xtg.ts
@@ -1,3 +1,11 @@
+function createDigestSeed(data: Uint8Array): Uint8Array {
+  const digest = new Uint8Array(8)
+  for (let i = 0; i < Math.min(8, data.length); i++) {
+    digest[i] = data[i]
+  }
+  return digest
+}
+
 /**
  * Convert ImageData to XTG format (XTEink Graphics).
  */
@@ -21,26 +29,75 @@ export function imageDataToXtg(imageData: ImageData): ArrayBuffer {
     }
   }
 
-  // Create MD5-like digest (simplified)
-  const md5digest = new Uint8Array(8)
-  for (let i = 0; i < Math.min(8, pixelData.length); i++) {
-    md5digest[i] = pixelData[i]
+  return buildPageBuffer('XTG', w, h, pixelData)
+}
+
+export function imageDataToXth(imageData: ImageData): ArrayBuffer {
+  const w = imageData.width
+  const h = imageData.height
+  const data = imageData.data
+
+  const colBytes = Math.ceil(h / 8)
+  const planeSize = colBytes * w
+  const plane0 = new Uint8Array(planeSize)
+  const plane1 = new Uint8Array(planeSize)
+
+  for (let x = 0; x < w; x++) {
+    const targetCol = w - 1 - x
+    const colOffset = targetCol * colBytes
+
+    for (let y = 0; y < h; y++) {
+      const idx = (y * w + x) * 4
+      const value = get2BitLevel(data[idx])
+      const byteIndex = colOffset + (y >> 3)
+      const bitIndex = 7 - (y & 7)
+
+      if (value & 1) {
+        plane0[byteIndex] |= 1 << bitIndex
+      }
+      if (value & 2) {
+        plane1[byteIndex] |= 1 << bitIndex
+      }
+    }
   }
 
+  const pixelData = new Uint8Array(planeSize * 2)
+  pixelData.set(plane0)
+  pixelData.set(plane1, planeSize)
+
+  return buildPageBuffer('XTH', w, h, pixelData)
+}
+
+function get2BitLevel(value: number): number {
+  if (value >= 212) return 0
+  if (value >= 127) return 1
+  if (value >= 42) return 2
+  return 3
+}
+
+function buildPageBuffer(
+  magic: 'XTG' | 'XTH',
+  width: number,
+  height: number,
+  pixelData: Uint8Array
+): ArrayBuffer {
+  const digest = createDigestSeed(pixelData)
   const headerSize = 22
   const totalSize = headerSize + pixelData.length
   const buffer = new ArrayBuffer(totalSize)
   const view = new DataView(buffer)
   const uint8 = new Uint8Array(buffer)
 
-  // XTG header
-  uint8[0] = 0x58; uint8[1] = 0x54; uint8[2] = 0x47; uint8[3] = 0x00
-  view.setUint16(4, w, true)
-  view.setUint16(6, h, true)
+  uint8[0] = magic.charCodeAt(0)
+  uint8[1] = magic.charCodeAt(1)
+  uint8[2] = magic.charCodeAt(2)
+  uint8[3] = 0x00
+  view.setUint16(4, width, true)
+  view.setUint16(6, height, true)
   view.setUint8(8, 0)
   view.setUint8(9, 0)
   view.setUint32(10, pixelData.length, true)
-  uint8.set(md5digest, 14)
+  uint8.set(digest, 14)
 
   uint8.set(pixelData, headerSize)
   return buffer

--- a/src/routes/image.tsx
+++ b/src/routes/image.tsx
@@ -9,7 +9,7 @@ function ImagePage() {
   return (
     <ConverterPage
       fileType="image"
-      notice="Convert image files to XTC with dedicated scaling modes for wallpapers and covers."
+      notice="Convert image files to XTC or XTCH with dedicated scaling modes for wallpapers and covers."
     />
   )
 }


### PR DESCRIPTION
## Summary
- add an image-only `Use XTCH 2-bit grayscale output` option on `/image`
- add `XTH` page encoding and 2-bit dithering support for image conversions
- keep CBZ, CBR, PDF, video, merge/split, workers, and non-image copy unchanged

## Details
- `ConversionOptions` now includes `is2bit`, but this PR only honors it in the standalone image conversion path
- `/image` emits `.xtch` and passes `is2bit` into `buildXtcFromXtgPages(...)` only when the new option is enabled
- non-image converters continue to emit `.xtc` and keep their existing 1-bit processing flow

## Verification
- `bun run build`
