### PR TITLE
Add PDF four-way column split mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ Your content is automatically processed for the best e-ink reading experience:
 <details>
 <summary><b>Why are my pages split in half?</b></summary>
 
-The XTEink X4 has a portrait screen. When you convert landscape images (like two-page manga spreads), XTC.js splits them so you can read each page comfortably. Use "No split" if you prefer full spreads.
+The XTEink X4 has a portrait screen. When you convert landscape images (like two-page manga spreads), XTC.js splits them so you can read each page comfortably. Use "No split" if you prefer full spreads. PDFs also support a "Split by columns (4-way)" option for two-column layouts.
 </details>
 
 <details>
@@ -155,4 +155,3 @@ bun run dev      # Dev server → localhost:5173
 bun run build    # Production build
 bun run serve    # Production server → localhost:3000
 ```
-

--- a/src/components/Options.tsx
+++ b/src/components/Options.tsx
@@ -139,6 +139,9 @@ export function Options({ options, onChange, fileType = 'cbz' }: OptionsProps) {
             >
               <option value="overlap">Overlapping thirds</option>
               <option value="split">Split in half</option>
+              {fileType === 'pdf' && (
+                <option value="fourway">Split by columns (4-way)</option>
+              )}
               <option value="nosplit">No split</option>
             </select>
           </div>

--- a/src/lib/conversion/types.ts
+++ b/src/lib/conversion/types.ts
@@ -1,4 +1,4 @@
-export type SplitMode = 'overlap' | 'split' | 'nosplit'
+export type SplitMode = 'overlap' | 'split' | 'fourway' | 'nosplit'
 export type PageOverviewMode = 'none' | 'portrait' | 'landscape'
 
 export interface ConversionOptions {

--- a/src/lib/converter.ts
+++ b/src/lib/converter.ts
@@ -4,7 +4,7 @@ import JSZip from 'jszip'
 import { createExtractorFromData } from 'node-unrar-js'
 import unrarWasm from 'node-unrar-js/esm/js/unrar.wasm?url'
 import { applyDithering } from './processing/dithering'
-import { toGrayscale, applyContrast, calculateOverlapSegments } from './processing/image'
+import { toGrayscale, applyContrast, calculateOverlapSegments, calculateFourWaySegments } from './processing/image'
 import { rotateCanvas, extractAndRotate, resizeWithPadding, getTargetDimensions } from './processing/canvas'
 import { imageDataToXtg, imageDataToXth } from './processing/xtg'
 import { buildXtcFromXtgPages } from './xtc-format'
@@ -882,6 +882,19 @@ function processCanvasAsImage(
           canvas: finalCanvas
         })
       })
+    } else if (options.splitMode === 'fourway') {
+      const segments = calculateFourWaySegments(width, height)
+      segments.forEach((seg, idx) => {
+        const letter = String.fromCharCode(97 + idx)
+        const pageCanvas = extractAndRotate(canvas, seg.x, seg.y, seg.w, seg.h, landscapeRotation)
+        const finalCanvas = resizeWithPadding(pageCanvas, 255, targetWidth, targetHeight)
+        applyDithering(finalCanvas.getContext('2d')!, targetWidth, targetHeight, options.dithering)
+
+        results.push({
+          name: `${String(pageNum).padStart(4, '0')}_4_${letter}.png`,
+          canvas: finalCanvas
+        })
+      })
     } else {
       const halfHeight = Math.floor(height / 2)
 
@@ -1011,6 +1024,19 @@ function processLoadedImage(
 
         results.push({
           name: `${String(pageNum).padStart(4, '0')}_3_${letter}.png`,
+          canvas: finalCanvas
+        })
+      })
+    } else if (options.splitMode === 'fourway') {
+      const segments = calculateFourWaySegments(width, height)
+      segments.forEach((seg, idx) => {
+        const letter = String.fromCharCode(97 + idx)
+        const pageCanvas = extractAndRotate(canvas, seg.x, seg.y, seg.w, seg.h, landscapeRotation)
+        const finalCanvas = resizeWithPadding(pageCanvas, 255, targetWidth, targetHeight)
+        applyDithering(finalCanvas.getContext('2d')!, targetWidth, targetHeight, options.dithering, is2bit)
+
+        results.push({
+          name: `${String(pageNum).padStart(4, '0')}_4_${letter}.png`,
           canvas: finalCanvas
         })
       })

--- a/src/lib/converter.ts
+++ b/src/lib/converter.ts
@@ -4,8 +4,8 @@ import JSZip from 'jszip'
 import { createExtractorFromData } from 'node-unrar-js'
 import unrarWasm from 'node-unrar-js/esm/js/unrar.wasm?url'
 import { applyDithering } from './processing/dithering'
-import { toGrayscale, applyContrast, calculateOverlapSegments, calculateFourWaySegments } from './processing/image'
-import { rotateCanvas, extractAndRotate, resizeWithPadding, getTargetDimensions } from './processing/canvas'
+import { toGrayscale, applyContrast, calculateOverlapSegments, calculateFourWaySegments, findContentBounds } from './processing/image'
+import { rotateCanvas, extractAndRotate, extractRegion, resizeWithPadding, getTargetDimensions } from './processing/canvas'
 import { imageDataToXtg, imageDataToXth } from './processing/xtg'
 import { buildXtcFromXtgPages } from './xtc-format'
 import { extractPdfMetadata } from './metadata/pdf-outline'
@@ -58,6 +58,19 @@ function buildOverviewPage(
     name: `${String(pageNum).padStart(4, '0')}_1_overview_${options.pageOverview}.png`,
     canvas: overviewCanvas
   }
+}
+
+function trimCanvasToContent(canvas: HTMLCanvasElement): HTMLCanvasElement {
+  const ctx = canvas.getContext('2d')
+  if (!ctx) return canvas
+
+  const bounds = findContentBounds(ctx.getImageData(0, 0, canvas.width, canvas.height))
+  if (!bounds) return canvas
+  if (bounds.width === canvas.width && bounds.height === canvas.height && bounds.x === 0 && bounds.y === 0) {
+    return canvas
+  }
+
+  return extractRegion(canvas, bounds.x, bounds.y, bounds.width, bounds.height)
 }
 
 function clampMarginPercent(value: number): number {
@@ -886,7 +899,9 @@ function processCanvasAsImage(
       const segments = calculateFourWaySegments(width, height)
       segments.forEach((seg, idx) => {
         const letter = String.fromCharCode(97 + idx)
-        const pageCanvas = extractAndRotate(canvas, seg.x, seg.y, seg.w, seg.h, landscapeRotation)
+        const segmentCanvas = extractRegion(canvas, seg.x, seg.y, seg.w, seg.h)
+        const trimmedSegment = trimCanvasToContent(segmentCanvas)
+        const pageCanvas = rotateCanvas(trimmedSegment, landscapeRotation)
         const finalCanvas = resizeWithPadding(pageCanvas, 255, targetWidth, targetHeight)
         applyDithering(finalCanvas.getContext('2d')!, targetWidth, targetHeight, options.dithering)
 
@@ -1031,7 +1046,9 @@ function processLoadedImage(
       const segments = calculateFourWaySegments(width, height)
       segments.forEach((seg, idx) => {
         const letter = String.fromCharCode(97 + idx)
-        const pageCanvas = extractAndRotate(canvas, seg.x, seg.y, seg.w, seg.h, landscapeRotation)
+        const segmentCanvas = extractRegion(canvas, seg.x, seg.y, seg.w, seg.h)
+        const trimmedSegment = trimCanvasToContent(segmentCanvas)
+        const pageCanvas = rotateCanvas(trimmedSegment, landscapeRotation)
         const finalCanvas = resizeWithPadding(pageCanvas, 255, targetWidth, targetHeight)
         applyDithering(finalCanvas.getContext('2d')!, targetWidth, targetHeight, options.dithering, is2bit)
 

--- a/src/lib/processing/image.ts
+++ b/src/lib/processing/image.ts
@@ -118,3 +118,23 @@ export function calculateOverlapSegments(
 
   return segments;
 }
+
+/**
+ * Split a page into four reading-order quadrants for two-column layouts.
+ */
+export function calculateFourWaySegments(
+  width: number,
+  height: number
+): Array<{ x: number; y: number; w: number; h: number }> {
+  const halfWidth = Math.floor(width / 2)
+  const rightWidth = width - halfWidth
+  const halfHeight = Math.floor(height / 2)
+  const bottomHeight = height - halfHeight
+
+  return [
+    { x: 0, y: 0, w: halfWidth, h: halfHeight },
+    { x: 0, y: halfHeight, w: halfWidth, h: bottomHeight },
+    { x: halfWidth, y: 0, w: rightWidth, h: halfHeight },
+    { x: halfWidth, y: halfHeight, w: rightWidth, h: bottomHeight }
+  ]
+}

--- a/src/lib/processing/image.ts
+++ b/src/lib/processing/image.ts
@@ -1,5 +1,12 @@
 // Image processing functions for manga optimization
 
+interface ContentBounds {
+  x: number
+  y: number
+  width: number
+  height: number
+}
+
 /**
  * Convert image to grayscale using luminosity method
  */
@@ -117,6 +124,55 @@ export function calculateOverlapSegments(
   }
 
   return segments;
+}
+
+/**
+ * Find the tight bounds around non-white content in a grayscale image.
+ */
+export function findContentBounds(
+  imageData: ImageData,
+  whiteThreshold = 245
+): ContentBounds | null {
+  const { data, width, height } = imageData
+  let minX = width
+  let minY = height
+  let maxX = -1
+  let maxY = -1
+
+  for (let y = 0; y < height; y++) {
+    const rowOffset = y * width * 4
+    for (let x = 0; x < width; x++) {
+      const pixelOffset = rowOffset + x * 4
+      if (data[pixelOffset] >= whiteThreshold) {
+        continue
+      }
+
+      minX = Math.min(minX, x)
+      minY = Math.min(minY, y)
+      maxX = Math.max(maxX, x)
+      maxY = Math.max(maxY, y)
+    }
+  }
+
+  if (maxX < 0 || maxY < 0) {
+    return null
+  }
+
+  const contentWidth = maxX - minX + 1
+  const contentHeight = maxY - minY + 1
+  const padX = Math.max(4, Math.floor(contentWidth * 0.04))
+  const padY = Math.max(4, Math.floor(contentHeight * 0.04))
+  const x = Math.max(0, minX - padX)
+  const y = Math.max(0, minY - padY)
+  const right = Math.min(width, maxX + padX + 1)
+  const bottom = Math.min(height, maxY + padY + 1)
+
+  return {
+    x,
+    y,
+    width: Math.max(1, right - x),
+    height: Math.max(1, bottom - y)
+  }
 }
 
 /**

--- a/src/lib/workers/convert-page.worker.ts
+++ b/src/lib/workers/convert-page.worker.ts
@@ -1,5 +1,5 @@
 import { applyDithering } from '../processing/dithering'
-import { applyContrast, calculateOverlapSegments, toGrayscale } from '../processing/image'
+import { applyContrast, calculateFourWaySegments, calculateOverlapSegments, toGrayscale } from '../processing/image'
 import { imageDataToXtg } from '../processing/xtg'
 import type { ConversionOptions } from '../conversion/types'
 
@@ -264,6 +264,29 @@ async function processBitmap(
 
         results.push(await buildWorkerPage(
           getPageName(pageNum, `3_${letter}`),
+          finalCanvas,
+          includePreview && !previewAssigned,
+          targetWidth,
+          targetHeight
+        ))
+        previewAssigned = true
+      }
+    } else if (options.splitMode === 'fourway') {
+      const segments = calculateFourWaySegments(width, height)
+      for (let idx = 0; idx < segments.length; idx++) {
+        const seg = segments[idx]
+        const letter = String.fromCharCode(97 + idx)
+        const pageCanvas = extractAndRotate(baseCanvas, seg.x, seg.y, seg.w, seg.h, landscapeRotation)
+        const finalCanvas = resizeWithPadding(pageCanvas, 255, targetWidth, targetHeight)
+        applyDithering(
+          asCanvas2d(finalCanvas.getContext('2d', { alpha: false })!),
+          targetWidth,
+          targetHeight,
+          options.dithering
+        )
+
+        results.push(await buildWorkerPage(
+          getPageName(pageNum, `4_${letter}`),
           finalCanvas,
           includePreview && !previewAssigned,
           targetWidth,

--- a/src/lib/workers/convert-page.worker.ts
+++ b/src/lib/workers/convert-page.worker.ts
@@ -1,5 +1,5 @@
 import { applyDithering } from '../processing/dithering'
-import { applyContrast, calculateFourWaySegments, calculateOverlapSegments, toGrayscale } from '../processing/image'
+import { applyContrast, calculateFourWaySegments, calculateOverlapSegments, findContentBounds, toGrayscale } from '../processing/image'
 import { imageDataToXtg } from '../processing/xtg'
 import type { ConversionOptions } from '../conversion/types'
 
@@ -101,6 +101,32 @@ function extractAndRotate(
   const ctx = extract.getContext('2d', { alpha: false })!
   ctx.drawImage(source, x, y, w, h, 0, 0, w, h)
   return rotateCanvas(extract, degrees)
+}
+
+function extractRegion(
+  source: OffscreenCanvas,
+  x: number,
+  y: number,
+  w: number,
+  h: number
+): OffscreenCanvas {
+  const extract = new OffscreenCanvas(w, h)
+  const ctx = extract.getContext('2d', { alpha: false })!
+  ctx.drawImage(source, x, y, w, h, 0, 0, w, h)
+  return extract
+}
+
+function trimCanvasToContent(canvas: OffscreenCanvas): OffscreenCanvas {
+  const ctx = canvas.getContext('2d', { alpha: false })
+  if (!ctx) return canvas
+
+  const bounds = findContentBounds(ctx.getImageData(0, 0, canvas.width, canvas.height))
+  if (!bounds) return canvas
+  if (bounds.width === canvas.width && bounds.height === canvas.height && bounds.x === 0 && bounds.y === 0) {
+    return canvas
+  }
+
+  return extractRegion(canvas, bounds.x, bounds.y, bounds.width, bounds.height)
 }
 
 function resizeWithPadding(
@@ -276,7 +302,9 @@ async function processBitmap(
       for (let idx = 0; idx < segments.length; idx++) {
         const seg = segments[idx]
         const letter = String.fromCharCode(97 + idx)
-        const pageCanvas = extractAndRotate(baseCanvas, seg.x, seg.y, seg.w, seg.h, landscapeRotation)
+        const segmentCanvas = extractRegion(baseCanvas, seg.x, seg.y, seg.w, seg.h)
+        const trimmedSegment = trimCanvasToContent(segmentCanvas)
+        const pageCanvas = rotateCanvas(trimmedSegment, landscapeRotation)
         const finalCanvas = resizeWithPadding(pageCanvas, 255, targetWidth, targetHeight)
         applyDithering(
           asCanvas2d(finalCanvas.getContext('2d', { alpha: false })!),


### PR DESCRIPTION
## Summary
- add a PDF-only landscape split option for two-column pages
- split four-way in reading order: upper-left, lower-left, upper-right, lower-right
- keep existing split modes, defaults, and UI behavior unchanged outside the PDF selector

## Testing
- npm run build

Closes #24