### PR TITLE
Add portrait cover option for landscape books

### DIFF
--- a/src/components/ConverterPage.tsx
+++ b/src/components/ConverterPage.tsx
@@ -131,6 +131,7 @@ export function ConverterPage({ fileType, notice }: ConverterPageProps) {
     horizontalMargin: 0,
     verticalMargin: 0,
     orientation: (fileType === 'image' || fileType === 'video') ? 'portrait' : 'landscape',
+    coverPortrait: false,
     landscapeFlipClockwise: false,
     showProgressPreview: true,
     imageMode: fileType === 'image' ? 'cover' : 'letterbox',

--- a/src/components/Options.tsx
+++ b/src/components/Options.tsx
@@ -12,6 +12,7 @@ export function Options({ options, onChange, fileType = 'cbz' }: OptionsProps) {
   const isImageMode = fileType === 'image'
   const isVideoMode = fileType === 'video'
   const supportsSplit = !isImageMode && !isVideoMode && options.orientation === 'landscape'
+  const supportsCoverPortrait = !isImageMode && !isVideoMode && options.orientation === 'landscape'
   const showPageOverview = supportsSplit &&
     options.splitMode !== 'nosplit' &&
     (fileType === 'cbz' || fileType === 'pdf')
@@ -77,6 +78,20 @@ export function Options({ options, onChange, fileType = 'cbz' }: OptionsProps) {
                 onChange={(e) => onChange({ ...options, landscapeFlipClockwise: e.target.checked })}
               />
               <span>Flip landscape clockwise</span>
+            </label>
+          </div>
+        )}
+
+        {supportsCoverPortrait && (
+          <div className="option option-checkbox">
+            <label htmlFor="coverPortrait" className="checkbox-label">
+              <input
+                type="checkbox"
+                id="coverPortrait"
+                checked={options.coverPortrait}
+                onChange={(e) => onChange({ ...options, coverPortrait: e.target.checked })}
+              />
+              <span>Keep cover portrait</span>
             </label>
           </div>
         )}

--- a/src/lib/conversion/types.ts
+++ b/src/lib/conversion/types.ts
@@ -11,6 +11,7 @@ export interface ConversionOptions {
   horizontalMargin: number
   verticalMargin: number
   orientation: 'landscape' | 'portrait'
+  coverPortrait: boolean
   landscapeFlipClockwise: boolean
   showProgressPreview: boolean
   imageMode: 'cover' | 'letterbox' | 'fill' | 'crop'

--- a/src/lib/converter.ts
+++ b/src/lib/converter.ts
@@ -150,11 +150,22 @@ function getPageProcessingOptions(
   baseOptions: ConversionOptions,
   isCoverPage: boolean
 ): ConversionOptions {
-  // Crosspoint uses XTC page 0 as the home preview, so keep cover full-size.
-  if (!isCoverPage || baseOptions.splitMode === 'nosplit') {
+  if (!isCoverPage) {
     return baseOptions
   }
-  return { ...baseOptions, splitMode: 'nosplit' }
+
+  let coverOptions = baseOptions
+
+  // Crosspoint uses XTC page 0 as the home preview, so keep cover full-size.
+  if (coverOptions.splitMode !== 'nosplit') {
+    coverOptions = { ...coverOptions, splitMode: 'nosplit' }
+  }
+
+  if (coverOptions.coverPortrait && coverOptions.orientation === 'landscape') {
+    coverOptions = { ...coverOptions, orientation: 'portrait' }
+  }
+
+  return coverOptions
 }
 
 function getOutputDimensions(options: ConversionOptions): { width: number; height: number } {


### PR DESCRIPTION
## Summary
- add a `Keep cover portrait` option for landscape comic and PDF conversions
- process the first page as portrait and no-split when the new option is enabled, while keeping the remaining pages in the selected landscape flow
- keep existing defaults and output unchanged unless the new option is turned on

## Testing
- `bun run build`

Closes #27
