### PR TITLE
Keep stored previews when live preview is disabled

### DIFF
--- a/src/components/ConverterPage.tsx
+++ b/src/components/ConverterPage.tsx
@@ -114,6 +114,7 @@ export function ConverterPage({ fileType, notice }: ConverterPageProps) {
   const [progressText, setProgressText] = useState('Processing...')
   const [isDownloadAllLoading, setIsDownloadAllLoading] = useState(false)
   const [previewUrl, setPreviewUrl] = useState<string | null>(null)
+  const [previewError, setPreviewError] = useState<string | null>(null)
   const [viewerPages, setViewerPages] = useState<string[]>([])
   const progressPreviewRef = useRef<string | null>(null)
   const pendingProgressRef = useRef<number | null>(null)
@@ -197,6 +198,7 @@ export function ConverterPage({ fileType, notice }: ConverterPageProps) {
 
     setIsConverting(true)
     await clearSession() // Clear previous session results
+    setPreviewError(null)
     setProgress(0)
     setProgressText('Processing...')
     if (progressPreviewRef.current && progressPreviewRef.current.startsWith('blob:')) {
@@ -270,35 +272,41 @@ export function ConverterPage({ fileType, notice }: ConverterPageProps) {
   }, [selectedFiles, fileType, options, addResult, clearSession, scheduleProgressUiFlush])
 
   const handlePreview = useCallback(async (result: StoredResult) => {
-    const cached = previewCacheRef.current.get(result.id)
-    if (cached && cached.length > 0) {
-      setViewerPages(cached)
-      return
-    }
+    try {
+      setPreviewError(null)
 
-    const images = await getPreviewImages(result)
-    if (images.length > 0) {
-      previewCacheRef.current.set(result.id, images)
-      setViewerPages(images)
-      return
-    }
+      const cached = previewCacheRef.current.get(result.id)
+      if (cached && cached.length > 0) {
+        setViewerPages(cached)
+        return
+      }
 
-    const data = await getResultData(result)
-    if (!data || data.byteLength === 0) {
+      const images = await getPreviewImages(result)
       if (images.length > 0) {
         previewCacheRef.current.set(result.id, images)
         setViewerPages(images)
+        return
       }
-      return
-    }
 
-    const decodeLimit = result.pageCount > MAX_FALLBACK_PREVIEW_PAGES
-      ? MAX_FALLBACK_PREVIEW_PAGES
-      : undefined
-    const canvases = await extractXtcPages(data, decodeLimit)
-    const decodedImages = canvases.map((canvas) => canvas.toDataURL('image/png'))
-    previewCacheRef.current.set(result.id, decodedImages)
-    setViewerPages(decodedImages)
+      const data = await getResultData(result)
+      if (!data || data.byteLength === 0) {
+        setPreviewError('Preview data is not available for this file.')
+        return
+      }
+
+      const decodeLimit = result.pageCount > MAX_FALLBACK_PREVIEW_PAGES
+        ? MAX_FALLBACK_PREVIEW_PAGES
+        : undefined
+      const canvases = await extractXtcPages(data, decodeLimit)
+      const decodedImages = canvases.map((canvas) => canvas.toDataURL('image/png'))
+      previewCacheRef.current.set(result.id, decodedImages)
+      setViewerPages(decodedImages)
+    } catch (err) {
+      console.error('Preview failed:', err)
+      setPreviewError(
+        normalizeUserErrorMessage(err instanceof Error ? err.message : 'Failed to generate preview')
+      )
+    }
   }, [getPreviewImages, getResultData])
 
   const handleCloseViewer = useCallback(() => {
@@ -398,6 +406,12 @@ export function ConverterPage({ fileType, notice }: ConverterPageProps) {
       {transferNotice && (
         <div className="transfer-notice">
           <p>{transferNotice}</p>
+        </div>
+      )}
+
+      {previewError && (
+        <div className="transfer-notice">
+          <p>Preview failed: {previewError}</p>
         </div>
       )}
 

--- a/src/lib/converter.ts
+++ b/src/lib/converter.ts
@@ -334,8 +334,7 @@ async function processArchiveSourcePages(
 
       const pageOptions = getPageOptions(index)
       const pageNum = index + 1
-      const includePreview = pageOptions.showProgressPreview &&
-        sampledPreviews.length < MAX_STORED_PREVIEWS &&
+      const includePreview = sampledPreviews.length < MAX_STORED_PREVIEWS &&
         shouldGenerateSampledPreview(pageNum, totalPages)
       const imgBlob = await getBlob(index)
 
@@ -352,7 +351,9 @@ async function processArchiveSourcePages(
             const previewBytes = workerPages.find((page) => page.previewJpeg)?.previewJpeg
             if (previewBytes) {
               const previewBlob = new Blob([previewBytes], { type: 'image/jpeg' })
-              previewForProgress = URL.createObjectURL(previewBlob)
+              if (pageOptions.showProgressPreview) {
+                previewForProgress = URL.createObjectURL(previewBlob)
+              }
               if (sampledPreviews.length < MAX_STORED_PREVIEWS) {
                 previewForStorage = await blobToDataUrl(previewBlob)
               }
@@ -373,7 +374,9 @@ async function processArchiveSourcePages(
 
         if (includePreview && pages.length > 0 && pages[0].canvas) {
           const previewDataUrl = pages[0].canvas.toDataURL('image/jpeg', PREVIEW_JPEG_QUALITY)
-          previewForProgress = previewDataUrl
+          if (pageOptions.showProgressPreview) {
+            previewForProgress = previewDataUrl
+          }
           if (sampledPreviews.length < MAX_STORED_PREVIEWS) {
             previewForStorage = previewDataUrl
           }
@@ -615,9 +618,12 @@ export async function convertImageToXtc(
 
   let previewUrl: string | null = null
   const sampledPreviews: string[] = []
-  if (options.showProgressPreview && imagePages[0]?.canvas) {
-    previewUrl = imagePages[0].canvas.toDataURL('image/jpeg', PREVIEW_JPEG_QUALITY)
-    sampledPreviews.push(previewUrl)
+  if (imagePages[0]?.canvas) {
+    const previewDataUrl = imagePages[0].canvas.toDataURL('image/jpeg', PREVIEW_JPEG_QUALITY)
+    sampledPreviews.push(previewDataUrl)
+    if (options.showProgressPreview) {
+      previewUrl = previewDataUrl
+    }
   }
   onProgress(1, previewUrl)
 
@@ -731,13 +737,12 @@ export async function convertVideoToXtc(
       encodedPages.push(...pages.map(encodeCanvasPage))
       mappingCtx.addOriginalPage(i + 1, pages.length)
 
-      const includePreview = options.showProgressPreview &&
-        sampledPreviews.length < MAX_STORED_PREVIEWS &&
+      const includePreview = sampledPreviews.length < MAX_STORED_PREVIEWS &&
         shouldGenerateSampledPreview(i + 1, frameCount)
       if (includePreview && pages.length > 0 && pages[0].canvas) {
         const previewDataUrl = pages[0].canvas.toDataURL('image/jpeg', PREVIEW_JPEG_QUALITY)
         sampledPreviews.push(previewDataUrl)
-        onProgress((i + 1) / frameCount, previewDataUrl)
+        onProgress((i + 1) / frameCount, options.showProgressPreview ? previewDataUrl : null)
       } else {
         onProgress((i + 1) / frameCount, null)
       }
@@ -799,13 +804,12 @@ async function convertPdfToXtc(
     encodedPages.push(...pages.map(encodeCanvasPage))
     mappingCtx.addOriginalPage(i, pages.length)
 
-    const includePreview = options.showProgressPreview &&
-      sampledPreviews.length < MAX_STORED_PREVIEWS &&
+    const includePreview = sampledPreviews.length < MAX_STORED_PREVIEWS &&
       shouldGenerateSampledPreview(i, numPages)
     if (includePreview && pages.length > 0 && pages[0].canvas) {
       const previewBlob = await canvasToBlob(pages[0].canvas, 'image/jpeg', PREVIEW_JPEG_QUALITY)
       const previewDataUrl = await blobToDataUrl(previewBlob)
-      onProgress(i / numPages, previewDataUrl)
+      onProgress(i / numPages, options.showProgressPreview ? previewDataUrl : null)
 
       if (sampledPreviews.length < MAX_STORED_PREVIEWS) {
         sampledPreviews.push(previewDataUrl)


### PR DESCRIPTION
## Summary
- keep sampled preview images stored even when `Show live progress preview` is turned off
- avoid forcing the Preview button onto the expensive full XTC decode path just because the live progress image was hidden
- catch preview decode failures and surface them as a notice instead of throwing through the UI

## Testing
- `bun run build`
