### PR TITLE
Add option: Apply page split to cover

### DIFF
--- a/src/components/ConverterPage.tsx
+++ b/src/components/ConverterPage.tsx
@@ -153,6 +153,7 @@ export function ConverterPage({ fileType, notice }: ConverterPageProps) {
     verticalMargin: 0,
     orientation: (fileType === 'image' || fileType === 'video') ? 'portrait' : 'landscape',
     coverPortrait: false,
+    applySplitToCover: false,
     landscapeFlipClockwise: false,
     showProgressPreview: true,
     imageMode: fileType === 'image' ? 'cover' : 'letterbox',

--- a/src/components/Options.tsx
+++ b/src/components/Options.tsx
@@ -96,6 +96,20 @@ export function Options({ options, onChange, fileType = 'cbz' }: OptionsProps) {
           </div>
         )}
 
+        {supportsCoverPortrait && (
+          <div className="option option-checkbox">
+            <label htmlFor="applySplitToCover" className="checkbox-label">
+              <input
+                type="checkbox"
+                id="applySplitToCover"
+                checked={options.applySplitToCover}
+                onChange={(e) => onChange({ ...options, applySplitToCover: e.target.checked })}
+              />
+              <span>Apply page split to cover</span>
+            </label>
+          </div>
+        )}
+
         {(isImageMode || isVideoMode) && (
           <div className="option">
             <label htmlFor="imageMode">Image Scaling</label>

--- a/src/lib/conversion/types.ts
+++ b/src/lib/conversion/types.ts
@@ -12,6 +12,7 @@ export interface ConversionOptions {
   verticalMargin: number
   orientation: 'landscape' | 'portrait'
   coverPortrait: boolean
+  applySplitToCover: boolean
   landscapeFlipClockwise: boolean
   showProgressPreview: boolean
   imageMode: 'cover' | 'letterbox' | 'fill' | 'crop'

--- a/src/lib/converter.ts
+++ b/src/lib/converter.ts
@@ -164,7 +164,7 @@ function getPageProcessingOptions(
   let coverOptions = baseOptions
 
   // Crosspoint uses XTC page 0 as the home preview, so keep cover full-size.
-  if (coverOptions.splitMode !== 'nosplit') {
+  if (!coverOptions.applySplitToCover && coverOptions.splitMode !== 'nosplit') {
     coverOptions = { ...coverOptions, splitMode: 'nosplit' }
   }
 


### PR DESCRIPTION
# Summary
- Not all `.cbz` files contain a portrait cover as its first page, some of them start on the first actual page (weekly chapter releases, etc). For these files: a global "no split, for the cover" makes the first page unreadable.
  - I previously worked around this by opening up the `.cbz`, adding a custom cover, then re-zip. Doable for 1 file, not so much for tens/hundreds of files
- Default behavior is kept, but user can now apply their chosen split option on the cover 