### PR TITLE
feat: polish the interface and add two-column PDF reading

### DIFF
--- a/docs/superpowers/plans/2026-07-29-revisuals.md
+++ b/docs/superpowers/plans/2026-07-29-revisuals.md
@@ -1,0 +1,239 @@
+# Revisuals Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Deliver a polished, low-cost local interface with individual result removal and upright four-page reading flow for two-column portrait PDFs.
+
+**Architecture:** Reuse the existing IndexedDB deletion primitive, result hook, crop calculator, converter paths, and paper-and-ink CSS. State ownership remains in `useStoredResults`; conversion paths share one pure split decision; visual changes use existing markup and theme variables.
+
+**Tech Stack:** React 19, TypeScript, Bun, Vite, IndexedDB, Canvas/OffscreenCanvas, CSS.
+
+## Global Constraints
+
+- Work only on local branch `revisuals`; do not push or open a pull request.
+- Use Bun, not npm.
+- Add no dependencies, backend, deployment configuration, or automatic layout detection.
+- Preserve existing conversion defaults and landscape split behavior.
+- Keep the current paper-and-ink identity and avoid resource-heavy effects.
+
+---
+
+### Task 1: Establish the Bun verification baseline
+
+**Files:**
+- Modify: `package.json`
+
+**Interfaces:**
+- Produces: `bun run test` as the repository test command.
+
+- [ ] **Step 1: Install locked dependencies**
+
+Run: `bun install --frozen-lockfile`
+
+- [ ] **Step 2: Run existing tests and production build**
+
+Run: `bun test && bun run build`
+
+Expected: existing tests and Vite build pass before application changes.
+
+- [ ] **Step 3: Add the Bun test script**
+
+```json
+"test": "bun test"
+```
+
+- [ ] **Step 4: Verify the script**
+
+Run: `bun run test`
+
+Expected: the same existing tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add package.json
+git commit -m "test: add Bun test command"
+```
+
+### Task 2: Remove one stored result
+
+**Files:**
+- Modify: `src/lib/storage.ts`
+- Modify: `src/hooks/useStoredResults.ts`
+- Modify: `src/components/Results.tsx`
+- Modify: `src/components/ConverterPage.tsx`
+- Modify: `src/styles/components.css`
+- Test: `src/hooks/useStoredResults.test.ts`
+
+**Interfaces:**
+- Produces: `removeResult(result: StoredResult): Promise<boolean>` from `useStoredResults`.
+- Produces: `onRemove(result: StoredResult)` on `Results`.
+- Reuses: `deleteConversion(id: string): Promise<void>` from `storage.ts`.
+
+- [ ] **Step 1: Write the failing state-removal test**
+
+```ts
+import { expect, test } from 'bun:test'
+import { withoutStoredResult } from './useStoredResults'
+
+test('removes only the requested stored result', () => {
+  const results = [{ id: 'one' }, { id: 'two' }]
+  expect(withoutStoredResult(results, 'one')).toEqual([{ id: 'two' }])
+})
+```
+
+- [ ] **Step 2: Verify RED**
+
+Run: `bun test src/hooks/useStoredResults.test.ts`
+
+Expected: FAIL because `withoutStoredResult` does not exist.
+
+- [ ] **Step 3: Implement minimal storage and hook behavior**
+
+Export the existing `deleteConversion`. Add `withoutStoredResult`, then add `removeResult` that deletes persisted records before filtering both current and recovered arrays. Skip IndexedDB for `mem-` IDs. Return `false` and retain state if deletion fails.
+
+- [ ] **Step 4: Wire the accessible remove action**
+
+Add `onRemove` to `Results`, render a `×` button with `aria-label="Remove <filename>"`, and have `ConverterPage` clear that result's preview cache only after successful removal.
+
+- [ ] **Step 5: Verify GREEN**
+
+Run: `bun test src/hooks/useStoredResults.test.ts && bun run build`
+
+Expected: test and build pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/lib/storage.ts src/hooks/useStoredResults.ts src/hooks/useStoredResults.test.ts src/components/Results.tsx src/components/ConverterPage.tsx src/styles/components.css
+git commit -m "feat: remove individual conversion results"
+```
+
+### Task 3: Add upright two-column paper output
+
+**Files:**
+- Modify: `src/lib/processing/image.ts`
+- Modify: `src/lib/processing/image.test.ts`
+- Modify: `src/lib/converter.ts`
+- Modify: `src/lib/workers/convert-page.worker.ts`
+- Modify: `src/components/Options.tsx`
+
+**Interfaces:**
+- Produces: `shouldSplitPage(width, height, orientation, splitMode): boolean`.
+- Reuses: `calculateFourWaySegments(width, height)` in reading order.
+
+- [ ] **Step 1: Write failing split-decision tests**
+
+```ts
+import { expect, test } from 'bun:test'
+import { shouldSplitPage } from './image'
+
+test('splits portrait pages only for four-page paper mode', () => {
+  expect(shouldSplitPage(1200, 1800, 'portrait', 'fourway')).toBe(true)
+  expect(shouldSplitPage(1200, 1800, 'portrait', 'nosplit')).toBe(false)
+})
+
+test('preserves landscape split rules', () => {
+  expect(shouldSplitPage(1200, 1800, 'landscape', 'overlap')).toBe(true)
+  expect(shouldSplitPage(1800, 1200, 'landscape', 'overlap')).toBe(false)
+})
+```
+
+- [ ] **Step 2: Verify RED**
+
+Run: `bun test src/lib/processing/image.test.ts`
+
+Expected: FAIL because `shouldSplitPage` does not exist.
+
+- [ ] **Step 3: Implement the shared split decision**
+
+Return true for portrait `fourway`; otherwise retain the current landscape rule (`width < height && splitMode !== 'nosplit'`).
+
+- [ ] **Step 4: Apply it to all conversion paths**
+
+In DOM canvas, image, and worker paths, let portrait four-way mode pass the early portrait return. Extract and trim the four existing segments, keep portrait segments upright, rotate only landscape segments, and suppress landscape overview pages in portrait mode.
+
+- [ ] **Step 5: Expose the focused PDF control**
+
+Show Page Split for portrait PDFs, label `fourway` as `Two-column paper (4 pages)`, and normalize unsupported portrait split modes to `nosplit` when orientation changes.
+
+- [ ] **Step 6: Verify GREEN**
+
+Run: `bun test src/lib/processing/image.test.ts && bun run build`
+
+Expected: split tests and build pass.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/lib/processing/image.ts src/lib/processing/image.test.ts src/lib/converter.ts src/lib/workers/convert-page.worker.ts src/components/Options.tsx
+git commit -m "feat: split two-column portrait PDFs"
+```
+
+### Task 4: Unify Metadata and theme styling
+
+**Files:**
+- Modify: `src/routes/metadata.tsx`
+- Modify: `src/styles/main.css`
+- Modify: `src/styles/components.css`
+- Modify: `src/styles/manga-search.css`
+
+**Interfaces:**
+- Reuses: `.converter-notice`, `.section-header`, `.metadata-card`, and root theme variables.
+
+- [ ] **Step 1: Replace the Metadata-only heading treatment**
+
+Use the same notice banner and section header hierarchy as Image and Video. Preserve all upload, editing, chapter, and download controls.
+
+- [ ] **Step 2: Correct theme contrast at the source**
+
+Replace hard-coded component whites/blacks with `--paper`, `--paper-dark`, `--ink`, and `--ink-light`; increase the dark muted-text token enough for small labels; retain accent colors for status and destructive actions.
+
+- [ ] **Step 3: Apply lightweight shared polish**
+
+Improve layout width, vertical rhythm, card separation, control focus states, result action placement, and mobile wrapping using CSS only. Keep effects to borders, color, and short transitions.
+
+- [ ] **Step 4: Build-check the styling changes**
+
+Run: `bun run build`
+
+Expected: Vite build passes with no TypeScript or CSS errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/routes/metadata.tsx src/styles/main.css src/styles/components.css src/styles/manga-search.css
+git commit -m "style: refine the paper and ink interface"
+```
+
+### Task 5: Browser, quality, and security verification
+
+**Files:**
+- Review only: all branch changes.
+
+**Interfaces:**
+- Validates: desktop/mobile, light/dark, Metadata, results, and PDF controls.
+
+- [ ] **Step 1: Run automated verification**
+
+Run: `bun run test && bun run build && bun audit && git diff --check origin/master...HEAD`
+
+Expected: all commands exit successfully with no test, build, audit, or whitespace failures.
+
+- [ ] **Step 2: Start the local application**
+
+Run: `bun run dev --host 0.0.0.0`
+
+- [ ] **Step 3: Inspect desktop and mobile views**
+
+Check `/`, `/pdf`, `/image`, `/video`, and `/metadata` at 1440×1000 and 390×844 in both themes. Confirm readable labels, visible focus states, no horizontal page overflow, and consistent banner/card typography.
+
+- [ ] **Step 4: Exercise changed behavior**
+
+Convert two small files and remove one result. Convert a two-column portrait PDF with `Two-column paper (4 pages)` and verify output order upper-left, lower-left, upper-right, lower-right with upright pages.
+
+- [ ] **Step 5: Review branch state**
+
+Run: `git status --short --branch && git log --oneline origin/master..HEAD`
+
+Expected: clean local `revisuals` branch with no push or PR.

--- a/docs/superpowers/specs/2026-07-29-revisuals-design.md
+++ b/docs/superpowers/specs/2026-07-29-revisuals-design.md
@@ -1,0 +1,39 @@
+# Revisuals Design
+
+## Goal
+
+Polish the existing XTC.js interface without changing its visual identity, conversion defaults, or browser-first architecture.
+
+## Scope
+
+- Add an accessible remove button to every completed or failed conversion result. Removing a stored result must delete its IndexedDB record and immediately remove it from the current or recovered result list.
+- Fix dark-mode contrast by replacing component-level hard-coded light colors with the existing paper-and-ink theme variables.
+- Bring the Metadata page into the same banner, typography, spacing, and control system used by the other Extra tools while retaining all metadata functionality.
+- Refine shared spacing, surfaces, controls, result cards, and responsive behavior using CSS only. Keep the existing paper-and-ink direction and avoid costly animation, images, or new packages.
+- Rename the existing PDF four-way split option to `Two-column paper (4 pages)` and make it available for portrait PDFs. Portrait output follows reading order: upper-left, lower-left, upper-right, lower-right, with upright crops and no rotation. Existing landscape behavior remains unchanged.
+
+## Architecture
+
+The work reuses existing boundaries rather than introducing new components or dependencies. `useStoredResults` owns individual deletion because it already synchronizes IndexedDB and result state. `Results` only renders and invokes the remove action. The existing four-way segment calculator remains the single crop definition for paper splitting; conversion entry points choose whether each crop is rotated based on output orientation.
+
+Visual changes remain in the existing shared stylesheets and Metadata route. Theme variables provide all foreground, background, border, and muted colors so light and dark modes use the same component rules.
+
+## Error Handling
+
+- In-memory results are removed from state without an IndexedDB operation.
+- IndexedDB deletion errors are logged and leave the result visible so the interface does not claim that retained data was removed.
+- Existing conversion and preview errors are unchanged.
+
+## Validation
+
+- Add a Bun test for individual stored-result deletion and state filtering.
+- Extend image-processing/conversion coverage for portrait four-way crop order and orientation.
+- Run the full Bun test suite, TypeScript/Vite production build, and dependency audit.
+- Inspect light and dark modes at desktop and mobile widths, including Metadata, result removal, and PDF paper controls.
+
+## Non-goals
+
+- No Manga Search backend replacement. The public API tunnel is currently offline; the existing direct nyaa.si fallback remains.
+- No boarding-pass or ticket tool.
+- No automatic document-layout detection.
+- No new dependency, backend, deployment, push, or pull request.

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
+    "test": "bun test",
     "build:static": "VITE_API_URL=https://api.xtcjs.app/api vite build",
     "preview": "vite preview",
     "serve": "bun run server/index.ts",

--- a/src/components/ConverterPage.tsx
+++ b/src/components/ConverterPage.tsx
@@ -82,6 +82,7 @@ export function ConverterPage({ fileType, notice }: ConverterPageProps) {
     clearSession,
     clearAll,
     dismissRecovered,
+    removeResult,
     downloadResult,
     getPreviewImages,
     getResultData,
@@ -357,6 +358,12 @@ export function ConverterPage({ fileType, notice }: ConverterPageProps) {
     }
   }, [downloadResult])
 
+  const handleRemoveResult = useCallback(async (result: StoredResult) => {
+    if (await removeResult(result)) {
+      previewCacheRef.current.delete(result.id)
+    }
+  }, [removeResult])
+
   const handleDownloadAll = useCallback(async () => {
     if (isDownloadAllLoading) {
       return
@@ -494,6 +501,7 @@ export function ConverterPage({ fileType, notice }: ConverterPageProps) {
         downloadAllCount={downloadableCount}
         isDownloadAllLoading={isDownloadAllLoading}
         onPreview={handlePreview}
+        onRemove={handleRemoveResult}
         onClear={results.length > 0 ? handleClearResults : undefined}
       />
 

--- a/src/components/Options.test.tsx
+++ b/src/components/Options.test.tsx
@@ -1,0 +1,34 @@
+import { expect, test } from 'bun:test'
+import { renderToStaticMarkup } from 'react-dom/server'
+import type { ConversionOptions } from '../lib/converter'
+import { normalizeSplitModeForOrientation, Options } from './Options'
+
+function renderPdfOptions(orientation: ConversionOptions['orientation']) {
+  const options: ConversionOptions = {
+    device: 'X4',
+    splitMode: 'nosplit',
+    pageOverview: 'none',
+    dithering: 'atkinson',
+    is2bit: false,
+    contrast: 0,
+    horizontalMargin: 0,
+    verticalMargin: 0,
+    orientation,
+    coverPortrait: false,
+    landscapeFlipClockwise: false,
+    showProgressPreview: false,
+    imageMode: 'letterbox',
+    videoFps: 1,
+  }
+
+  return renderToStaticMarkup(<Options options={options} onChange={() => {}} fileType="pdf" />)
+}
+
+test('offers two-column paper splitting only in portrait PDF mode', () => {
+  expect(renderPdfOptions('portrait')).toContain('Two-column paper (4 pages)')
+  expect(renderPdfOptions('landscape')).not.toContain('Two-column paper (4 pages)')
+})
+
+test('clears portrait paper splitting when returning to landscape', () => {
+  expect(normalizeSplitModeForOrientation('landscape', 'fourway')).toBe('overlap')
+})

--- a/src/components/Options.tsx
+++ b/src/components/Options.tsx
@@ -7,6 +7,13 @@ interface OptionsProps {
   fileType?: 'cbz' | 'pdf' | 'image' | 'video'
 }
 
+export function normalizeSplitModeForOrientation(
+  orientation: ConversionOptions['orientation'],
+  splitMode: ConversionOptions['splitMode']
+): ConversionOptions['splitMode'] {
+  return orientation === 'portrait' ? 'nosplit' : splitMode === 'fourway' ? 'overlap' : splitMode
+}
+
 export function Options({ options, onChange, fileType = 'cbz' }: OptionsProps) {
   const [showAdvanced, setShowAdvanced] = useState(false)
   const isImageMode = fileType === 'image'
@@ -32,9 +39,9 @@ export function Options({ options, onChange, fileType = 'cbz' }: OptionsProps) {
               className={options.device === 'X4' ? 'active' : ''}
               aria-pressed={options.device === 'X4'}
               onClick={() => onChange({ ...options, device: 'X4' })}
-              title="XTEink X4 (480 x 800)"
+              title="XTEink X4 / X4 Pro (480 x 800)"
             >
-              [X4]
+              [X4 / Pro]
             </button>
             <button
               type="button"
@@ -46,9 +53,6 @@ export function Options({ options, onChange, fileType = 'cbz' }: OptionsProps) {
               [X3]
             </button>
           </fieldset>
-          {options.device === 'X3' && (
-            <p className="device-warning">WARNING: Select only if you are using the X3 device.</p>
-          )}
         </div>
       </aside>
 
@@ -67,9 +71,7 @@ export function Options({ options, onChange, fileType = 'cbz' }: OptionsProps) {
               onChange({
                 ...options,
                 orientation,
-                splitMode: orientation === 'portrait' && options.splitMode !== 'fourway'
-                  ? 'nosplit'
-                  : options.splitMode
+                splitMode: normalizeSplitModeForOrientation(orientation, options.splitMode)
               })
             }}
           >
@@ -130,7 +132,7 @@ export function Options({ options, onChange, fileType = 'cbz' }: OptionsProps) {
               checked={options.is2bit}
               onChange={(e) => onChange({ ...options, is2bit: e.target.checked })}
             />
-            <span>2-bit grayscale (XTCH) - 4 gray levels, better shading, ~2x file size</span>
+            <span>2-bit grayscale (XTCH)</span>
           </label>
         </div>
 
@@ -162,7 +164,7 @@ export function Options({ options, onChange, fileType = 'cbz' }: OptionsProps) {
             >
               {options.orientation === 'landscape' && <option value="overlap">Overlapping thirds</option>}
               {options.orientation === 'landscape' && <option value="split">Split in half</option>}
-              {fileType === 'pdf' && (
+              {fileType === 'pdf' && options.orientation === 'portrait' && (
                 <option value="fourway">Two-column paper (4 pages)</option>
               )}
               <option value="nosplit">No split</option>

--- a/src/components/Options.tsx
+++ b/src/components/Options.tsx
@@ -11,9 +11,10 @@ export function Options({ options, onChange, fileType = 'cbz' }: OptionsProps) {
   const [showAdvanced, setShowAdvanced] = useState(false)
   const isImageMode = fileType === 'image'
   const isVideoMode = fileType === 'video'
-  const supportsSplit = !isImageMode && !isVideoMode && options.orientation === 'landscape'
+  const supportsSplit = !isImageMode && !isVideoMode &&
+    (options.orientation === 'landscape' || fileType === 'pdf')
   const supportsCoverPortrait = !isImageMode && !isVideoMode && options.orientation === 'landscape'
-  const showPageOverview = supportsSplit &&
+  const showPageOverview = options.orientation === 'landscape' && supportsSplit &&
     options.splitMode !== 'nosplit' &&
     (fileType === 'cbz' || fileType === 'pdf')
 
@@ -61,7 +62,16 @@ export function Options({ options, onChange, fileType = 'cbz' }: OptionsProps) {
           <select
             id="orientation"
             value={options.orientation}
-            onChange={(e) => onChange({ ...options, orientation: e.target.value as 'landscape' | 'portrait' })}
+            onChange={(e) => {
+              const orientation = e.target.value as 'landscape' | 'portrait'
+              onChange({
+                ...options,
+                orientation,
+                splitMode: orientation === 'portrait' && options.splitMode !== 'fourway'
+                  ? 'nosplit'
+                  : options.splitMode
+              })
+            }}
           >
             <option value="landscape">Landscape</option>
             <option value="portrait">Portrait</option>
@@ -150,10 +160,10 @@ export function Options({ options, onChange, fileType = 'cbz' }: OptionsProps) {
               value={options.splitMode}
               onChange={(e) => onChange({ ...options, splitMode: e.target.value as ConversionOptions['splitMode'] })}
             >
-              <option value="overlap">Overlapping thirds</option>
-              <option value="split">Split in half</option>
+              {options.orientation === 'landscape' && <option value="overlap">Overlapping thirds</option>}
+              {options.orientation === 'landscape' && <option value="split">Split in half</option>}
               {fileType === 'pdf' && (
-                <option value="fourway">Split by columns (4-way)</option>
+                <option value="fourway">Two-column paper (4 pages)</option>
               )}
               <option value="nosplit">No split</option>
             </select>

--- a/src/components/Options.tsx
+++ b/src/components/Options.tsx
@@ -132,7 +132,7 @@ export function Options({ options, onChange, fileType = 'cbz' }: OptionsProps) {
               checked={options.is2bit}
               onChange={(e) => onChange({ ...options, is2bit: e.target.checked })}
             />
-            <span>2-bit grayscale (XTCH)</span>
+            <span>2-bit grayscale (XTCH, experimental)</span>
           </label>
         </div>
 

--- a/src/components/Results.tsx
+++ b/src/components/Results.tsx
@@ -10,6 +10,7 @@ interface ResultsProps {
   downloadAllCount?: number
   isDownloadAllLoading?: boolean
   onClear?: () => void | Promise<void>
+  onRemove: (result: StoredResult) => void | Promise<void>
 }
 
 export function Results({
@@ -20,6 +21,7 @@ export function Results({
   downloadAllCount = 0,
   isDownloadAllLoading = false,
   onClear,
+  onRemove,
 }: ResultsProps) {
   if (results.length === 0) {
     return null
@@ -73,24 +75,34 @@ export function Results({
                 </div>
               )}
             </div>
-            {!result.error && (
-              <div className="result-actions">
-                <button
-                  type="button"
-                  className="btn-preview"
-                  onClick={() => onPreview(result)}
-                >
-                  Preview
-                </button>
-                <button
-                  type="button"
-                  className="btn-download"
-                  onClick={() => onDownload(result)}
-                >
-                  Download
-                </button>
-              </div>
-            )}
+            <div className="result-actions">
+              {!result.error && (
+                <>
+                  <button
+                    type="button"
+                    className="btn-preview"
+                    onClick={() => onPreview(result)}
+                  >
+                    Preview
+                  </button>
+                  <button
+                    type="button"
+                    className="btn-download"
+                    onClick={() => onDownload(result)}
+                  >
+                    Download
+                  </button>
+                </>
+              )}
+              <button
+                type="button"
+                className="btn-remove-result"
+                onClick={() => onRemove(result)}
+                aria-label={`Remove ${result.name}`}
+              >
+                &times;
+              </button>
+            </div>
           </div>
         ))}
       </div>

--- a/src/hooks/useStoredResults.test.ts
+++ b/src/hooks/useStoredResults.test.ts
@@ -1,0 +1,7 @@
+import { expect, test } from 'bun:test'
+import { withoutStoredResult } from './useStoredResults'
+
+test('removes only the requested stored result', () => {
+  const results = [{ id: 'one' }, { id: 'two' }]
+  expect(withoutStoredResult(results, 'one')).toEqual([{ id: 'two' }])
+})

--- a/src/hooks/useStoredResults.test.ts
+++ b/src/hooks/useStoredResults.test.ts
@@ -1,7 +1,40 @@
 import { expect, test } from 'bun:test'
-import { withoutStoredResult } from './useStoredResults'
+import { deleteStoredResult, withoutStoredResult } from './useStoredResults'
 
 test('removes only the requested stored result', () => {
   const results = [{ id: 'one' }, { id: 'two' }]
   expect(withoutStoredResult(results, 'one')).toEqual([{ id: 'two' }])
+})
+
+test('waits for persisted deletion before succeeding', async () => {
+  let resolveDeletion!: () => void
+  let completed = false
+  const removal = deleteStoredResult({ id: 'stored-one' }, () => new Promise<void>((resolve) => {
+    resolveDeletion = resolve
+  }))
+  void removal.then(() => {
+    completed = true
+  })
+
+  await Promise.resolve()
+  expect(completed).toBe(false)
+
+  resolveDeletion()
+  await expect(removal).resolves.toBe(true)
+})
+
+test('skips persisted deletion for in-memory results', async () => {
+  let deleted = false
+
+  await expect(deleteStoredResult({ id: 'mem-one' }, async () => {
+    deleted = true
+  })).resolves.toBe(true)
+
+  expect(deleted).toBe(false)
+})
+
+test('returns false when persisted deletion fails', async () => {
+  await expect(deleteStoredResult({ id: 'stored-one' }, async () => {
+    throw new Error('delete failed')
+  })).resolves.toBe(false)
 })

--- a/src/hooks/useStoredResults.ts
+++ b/src/hooks/useStoredResults.ts
@@ -6,6 +6,7 @@ import {
   storeConversion,
   getConversionData,
   getConversionPreviews,
+  deleteConversion,
   deleteSessionConversions,
   clearAllConversions,
   cleanupExpiredConversions,
@@ -19,6 +20,10 @@ export interface StoredResult extends StoredConversionRef {
   // For compatibility with ConversionResult interface used by Results component
 }
 
+export function withoutStoredResult<T extends { id: string }>(results: T[], id: string): T[] {
+  return results.filter((result) => result.id !== id)
+}
+
 interface UseStoredResultsReturn {
   results: StoredResult[]
   recoveredResults: StoredResult[]
@@ -28,6 +33,7 @@ interface UseStoredResultsReturn {
   clearSession: () => Promise<void>
   clearAll: () => Promise<void>
   dismissRecovered: () => void
+  removeResult: (result: StoredResult) => Promise<boolean>
   downloadResult: (result: StoredResult) => Promise<void>
   getPreviewImages: (result: StoredResult) => Promise<string[]>
   getResultData: (result: StoredResult) => Promise<ArrayBuffer | null>
@@ -145,6 +151,21 @@ export function useStoredResults(): UseStoredResultsReturn {
     setRecoveredResults([])
   }, [])
 
+  const removeResult = useCallback(async (result: StoredResult): Promise<boolean> => {
+    try {
+      if (!result.id.startsWith('mem-')) {
+        await deleteConversion(result.id)
+      }
+    } catch (err) {
+      console.error('Failed to remove result:', err)
+      return false
+    }
+
+    setResults((prev) => withoutStoredResult(prev, result.id))
+    setRecoveredResults((prev) => withoutStoredResult(prev, result.id))
+    return true
+  }, [])
+
   // Download a result by fetching data from IndexedDB
   const downloadResult = useCallback(async (result: StoredResult): Promise<void> => {
     if (result.error) return
@@ -200,6 +221,7 @@ export function useStoredResults(): UseStoredResultsReturn {
     clearSession,
     clearAll,
     dismissRecovered,
+    removeResult,
     downloadResult,
     getPreviewImages,
     getResultData,

--- a/src/hooks/useStoredResults.ts
+++ b/src/hooks/useStoredResults.ts
@@ -24,6 +24,20 @@ export function withoutStoredResult<T extends { id: string }>(results: T[], id: 
   return results.filter((result) => result.id !== id)
 }
 
+export async function deleteStoredResult(
+  result: Pick<StoredResult, 'id'>,
+  deletePersisted: (id: string) => Promise<void> = deleteConversion,
+): Promise<boolean> {
+  if (result.id.startsWith('mem-')) return true
+
+  try {
+    await deletePersisted(result.id)
+    return true
+  } catch {
+    return false
+  }
+}
+
 interface UseStoredResultsReturn {
   results: StoredResult[]
   recoveredResults: StoredResult[]
@@ -152,12 +166,8 @@ export function useStoredResults(): UseStoredResultsReturn {
   }, [])
 
   const removeResult = useCallback(async (result: StoredResult): Promise<boolean> => {
-    try {
-      if (!result.id.startsWith('mem-')) {
-        await deleteConversion(result.id)
-      }
-    } catch (err) {
-      console.error('Failed to remove result:', err)
+    if (!await deleteStoredResult(result)) {
+      console.error('Failed to remove result')
       return false
     }
 

--- a/src/lib/converter.ts
+++ b/src/lib/converter.ts
@@ -4,7 +4,7 @@ import JSZip from 'jszip'
 import { createExtractorFromData } from 'node-unrar-js'
 import unrarWasm from 'node-unrar-js/esm/js/unrar.wasm?url'
 import { applyDithering } from './processing/dithering'
-import { toGrayscale, applyContrast, calculateOverlapSegments, calculateFourWaySegments, findContentBounds } from './processing/image'
+import { toGrayscale, applyContrast, calculateOverlapSegments, calculateFourWaySegments, findContentBounds, shouldSplitPage } from './processing/image'
 import { rotateCanvas, extractAndRotate, extractRegion, resizeWithPadding, getTargetDimensions } from './processing/canvas'
 import { imageDataToXtg, imageDataToXth } from './processing/xtg'
 import { buildXtcFromXtgPages } from './xtc-format'
@@ -895,7 +895,9 @@ function processCanvasAsImage(
 
   toGrayscale(ctx, width, height)
 
-  if (options.orientation === 'portrait') {
+  const shouldSplit = shouldSplitPage(width, height, options.orientation, options.splitMode)
+
+  if (options.orientation === 'portrait' && !shouldSplit) {
     const finalCanvas = applyImageMode(
       canvas,
       targetWidth,
@@ -913,10 +915,8 @@ function processCanvasAsImage(
   }
 
   const landscapeRotation = options.landscapeFlipClockwise ? -90 : 90
-  const shouldSplit = width < height && options.splitMode !== 'nosplit'
-
   if (shouldSplit) {
-    if (options.pageOverview !== 'none') {
+    if (options.orientation === 'landscape' && options.pageOverview !== 'none') {
       results.push(buildOverviewPage(canvas, pageNum, targetWidth, targetHeight, options, landscapeRotation))
     }
 
@@ -939,7 +939,9 @@ function processCanvasAsImage(
         const letter = String.fromCharCode(97 + idx)
         const segmentCanvas = extractRegion(canvas, seg.x, seg.y, seg.w, seg.h)
         const trimmedSegment = trimCanvasToContent(segmentCanvas)
-        const pageCanvas = rotateCanvas(trimmedSegment, landscapeRotation)
+        const pageCanvas = options.orientation === 'portrait'
+          ? trimmedSegment
+          : rotateCanvas(trimmedSegment, landscapeRotation)
         const finalCanvas = resizeWithPadding(pageCanvas, 255, targetWidth, targetHeight)
         applyDithering(finalCanvas.getContext('2d')!, targetWidth, targetHeight, options.dithering, options.is2bit)
 
@@ -1040,7 +1042,9 @@ function processLoadedImage(
 
   toGrayscale(ctx, width, height)
 
-  if (options.orientation === 'portrait') {
+  const shouldSplit = shouldSplitPage(width, height, options.orientation, options.splitMode)
+
+  if (options.orientation === 'portrait' && !shouldSplit) {
     const finalCanvas = applyImageMode(
       canvas,
       targetWidth,
@@ -1058,10 +1062,8 @@ function processLoadedImage(
   }
 
   const landscapeRotation = options.landscapeFlipClockwise ? -90 : 90
-  const shouldSplit = width < height && options.splitMode !== 'nosplit'
-
   if (shouldSplit) {
-    if (options.pageOverview !== 'none') {
+    if (options.orientation === 'landscape' && options.pageOverview !== 'none') {
       results.push(buildOverviewPage(canvas, pageNum, targetWidth, targetHeight, options, landscapeRotation))
     }
 
@@ -1084,7 +1086,9 @@ function processLoadedImage(
         const letter = String.fromCharCode(97 + idx)
         const segmentCanvas = extractRegion(canvas, seg.x, seg.y, seg.w, seg.h)
         const trimmedSegment = trimCanvasToContent(segmentCanvas)
-        const pageCanvas = rotateCanvas(trimmedSegment, landscapeRotation)
+        const pageCanvas = options.orientation === 'portrait'
+          ? trimmedSegment
+          : rotateCanvas(trimmedSegment, landscapeRotation)
         const finalCanvas = resizeWithPadding(pageCanvas, 255, targetWidth, targetHeight)
         applyDithering(finalCanvas.getContext('2d')!, targetWidth, targetHeight, options.dithering, options.is2bit)
 

--- a/src/lib/processing/image.test.ts
+++ b/src/lib/processing/image.test.ts
@@ -1,0 +1,12 @@
+import { expect, test } from 'bun:test'
+import { shouldSplitPage } from './image'
+
+test('splits portrait pages only for four-page paper mode', () => {
+  expect(shouldSplitPage(1200, 1800, 'portrait', 'fourway')).toBe(true)
+  expect(shouldSplitPage(1200, 1800, 'portrait', 'nosplit')).toBe(false)
+})
+
+test('preserves landscape split rules', () => {
+  expect(shouldSplitPage(1200, 1800, 'landscape', 'overlap')).toBe(true)
+  expect(shouldSplitPage(1800, 1200, 'landscape', 'overlap')).toBe(false)
+})

--- a/src/lib/processing/image.ts
+++ b/src/lib/processing/image.ts
@@ -194,3 +194,14 @@ export function calculateFourWaySegments(
     { x: halfWidth, y: halfHeight, w: rightWidth, h: bottomHeight }
   ]
 }
+
+export function shouldSplitPage(
+  width: number,
+  height: number,
+  orientation: 'landscape' | 'portrait',
+  splitMode: 'overlap' | 'split' | 'fourway' | 'nosplit'
+): boolean {
+  return orientation === 'portrait'
+    ? splitMode === 'fourway'
+    : width < height && splitMode !== 'nosplit'
+}

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -162,7 +162,7 @@ export async function getConversionPreviews(id: string): Promise<string[] | null
 /**
  * Delete a conversion record
  */
-async function deleteConversion(id: string): Promise<void> {
+export async function deleteConversion(id: string): Promise<void> {
   const db = await openDatabase()
 
   return new Promise((resolve, reject) => {

--- a/src/lib/workers/convert-page.worker.ts
+++ b/src/lib/workers/convert-page.worker.ts
@@ -1,5 +1,5 @@
 import { applyDithering } from '../processing/dithering'
-import { applyContrast, calculateFourWaySegments, calculateOverlapSegments, findContentBounds, toGrayscale } from '../processing/image'
+import { applyContrast, calculateFourWaySegments, calculateOverlapSegments, findContentBounds, shouldSplitPage, toGrayscale } from '../processing/image'
 import { imageDataToXtg, imageDataToXth } from '../processing/xtg'
 import type { ConversionOptions } from '../conversion/types'
 
@@ -244,7 +244,9 @@ async function processBitmap(
 
   toGrayscale(asCanvas2d(baseCtx), width, height)
 
-  if (options.orientation === 'portrait') {
+  const shouldSplit = shouldSplitPage(width, height, options.orientation, options.splitMode)
+
+  if (options.orientation === 'portrait' && !shouldSplit) {
     const finalCanvas = resizeWithPadding(baseCanvas, 255, targetWidth, targetHeight)
     applyDithering(
       asCanvas2d(finalCanvas.getContext('2d', { alpha: false })!),
@@ -265,11 +267,10 @@ async function processBitmap(
   }
 
   const landscapeRotation = options.landscapeFlipClockwise ? -90 : 90
-  const shouldSplit = width < height && options.splitMode !== 'nosplit'
   let previewAssigned = false
 
   if (shouldSplit) {
-    if (options.pageOverview !== 'none') {
+    if (options.orientation === 'landscape' && options.pageOverview !== 'none') {
       results.push(await buildOverviewWorkerPage(
         baseCanvas,
         pageNum,
@@ -314,7 +315,9 @@ async function processBitmap(
         const letter = String.fromCharCode(97 + idx)
         const segmentCanvas = extractRegion(baseCanvas, seg.x, seg.y, seg.w, seg.h)
         const trimmedSegment = trimCanvasToContent(segmentCanvas)
-        const pageCanvas = rotateCanvas(trimmedSegment, landscapeRotation)
+        const pageCanvas = options.orientation === 'portrait'
+          ? trimmedSegment
+          : rotateCanvas(trimmedSegment, landscapeRotation)
         const finalCanvas = resizeWithPadding(pageCanvas, 255, targetWidth, targetHeight)
         applyDithering(
           asCanvas2d(finalCanvas.getContext('2d', { alpha: false })!),

--- a/src/routes/metadata.tsx
+++ b/src/routes/metadata.tsx
@@ -153,10 +153,6 @@ function MetadataEditor() {
         <p>Edit title, author, and chapter information stored in an XTC or XTCH file.</p>
       </div>
 
-      <div className="section-header">
-        <h2 className="metadata-heading">Metadata Editor (XTC/XTCH)</h2>
-      </div>
-
       {!file && (
         <div className="dropzone-wrapper">
           <Dropzone onFiles={handleFileDrop} fileType="xtc" multiple={false} />

--- a/src/routes/metadata.tsx
+++ b/src/routes/metadata.tsx
@@ -148,13 +148,17 @@ function MetadataEditor() {
   }
 
   return (
-    <div className="content-section metadata-page" style={{ gridColumn: '1 / -1' }}>
-      <div className="section-header" style={{ marginBottom: 'var(--space-xl)' }}>
-        <h2 className="metadata-title">Metadata Editor (XTC/XTCH)</h2>
+    <div className="content-section metadata-page">
+      <div className="converter-notice">
+        <p>Edit title, author, and chapter information stored in an XTC or XTCH file.</p>
+      </div>
+
+      <div className="section-header">
+        <h2 className="metadata-heading">Metadata Editor (XTC/XTCH)</h2>
       </div>
 
       {!file && (
-        <div className="dropzone-wrapper" style={{ minHeight: '300px' }}>
+        <div className="dropzone-wrapper">
           <Dropzone onFiles={handleFileDrop} fileType="xtc" multiple={false} />
         </div>
       )}

--- a/src/styles/components.css
+++ b/src/styles/components.css
@@ -479,7 +479,8 @@
 }
 
 .btn-preview,
-.btn-download {
+.btn-download,
+.btn-remove-result {
   padding: var(--space-sm) var(--space-md);
   background: var(--paper);
   border: var(--border);
@@ -492,7 +493,8 @@
 }
 
 .btn-preview:hover,
-.btn-download:hover {
+.btn-download:hover,
+.btn-remove-result:hover {
   background: var(--ink);
   color: var(--paper);
 }

--- a/src/styles/components.css
+++ b/src/styles/components.css
@@ -155,17 +155,6 @@
   outline-color: var(--accent);
 }
 
-.device-warning {
-  max-width: 170px;
-  margin: 0.15rem 0 0;
-  text-align: right;
-  font-size: 0.62rem;
-  font-weight: 700;
-  letter-spacing: 0.04em;
-  line-height: 1.3;
-  color: var(--accent);
-}
-
 .option {
   margin-bottom: var(--space-md);
 }

--- a/src/styles/components.css
+++ b/src/styles/components.css
@@ -1136,10 +1136,6 @@
   margin-bottom: var(--space-xl);
 }
 
-.metadata-page > .section-header {
-  margin-bottom: var(--space-lg);
-}
-
 .metadata-page .dropzone {
   min-height: 300px;
   display: grid;

--- a/src/styles/components.css
+++ b/src/styles/components.css
@@ -14,7 +14,7 @@
   color: inherit;
   font: inherit;
   text-align: center;
-  transition: all 0.2s ease;
+  transition: background-color 0.2s ease, border-color 0.2s ease;
   outline: none;
 }
 
@@ -31,6 +31,10 @@
 .dropzone:focus-visible {
   border-color: var(--ink);
   background: var(--paper);
+}
+
+.dropzone:focus-visible {
+  outline-color: var(--accent);
 }
 
 .dropzone.dragover {
@@ -137,7 +141,7 @@
 }
 
 .device-toggle button:hover:not(.active) {
-  background: #fff;
+  background: var(--paper-dark);
   color: var(--ink);
 }
 
@@ -148,8 +152,7 @@
 }
 
 .device-toggle button:focus-visible {
-  outline: 2px solid var(--ink);
-  outline-offset: 1px;
+  outline-color: var(--accent);
 }
 
 .device-warning {
@@ -196,12 +199,12 @@
 
 .option select:hover,
 .option input:not([type="checkbox"]):hover {
-  background: #fff;
+  background: var(--paper-dark);
 }
 
-.option select:focus,
-.option input:not([type="checkbox"]):focus {
-  outline: 2px solid var(--ink);
+.option select:focus-visible,
+.option input:not([type="checkbox"]):focus-visible {
+  outline: 2px solid var(--accent);
   outline-offset: 1px;
 }
 
@@ -449,13 +452,20 @@
   gap: var(--space-md);
   padding: var(--space-md);
   background: var(--paper-dark);
-  border: var(--border);
+  border: var(--border-light);
+  border-left: 3px solid var(--ink);
+}
+
+.result-item > div:first-child {
+  min-width: 0;
 }
 
 .result-item .name {
+  display: block;
   font-family: var(--font-mono);
   font-size: 0.9rem;
   font-weight: 500;
+  overflow-wrap: anywhere;
 }
 
 .result-item .info {
@@ -475,27 +485,52 @@
 
 .result-actions {
   display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  justify-content: flex-end;
   gap: var(--space-xs);
+  flex-shrink: 0;
 }
 
 .btn-preview,
-.btn-download,
-.btn-remove-result {
+.btn-download {
   padding: var(--space-sm) var(--space-md);
   background: var(--paper);
   border: var(--border);
+  color: var(--ink);
   font-family: var(--font-mono);
   font-size: 0.8rem;
   font-weight: 500;
   cursor: pointer;
-  transition: all 0.15s;
+  transition: background-color 0.15s, color 0.15s, border-color 0.15s;
   white-space: nowrap;
 }
 
 .btn-preview:hover,
-.btn-download:hover,
-.btn-remove-result:hover {
+.btn-download:hover {
   background: var(--ink);
+  color: var(--paper);
+}
+
+.btn-remove-result {
+  width: 30px;
+  height: 30px;
+  margin-left: var(--space-xs);
+  padding: 0;
+  background: transparent;
+  border: var(--border-light);
+  color: var(--ink-faded);
+  font-family: var(--font-mono);
+  font-size: 1.1rem;
+  line-height: 1;
+  cursor: pointer;
+  flex: 0 0 auto;
+  transition: background-color 0.15s, color 0.15s, border-color 0.15s;
+}
+
+.btn-remove-result:hover {
+  background: var(--accent);
+  border-color: var(--accent);
   color: var(--paper);
 }
 
@@ -589,7 +624,7 @@
 .viewer-container {
   position: relative;
   overflow: hidden;
-  background: #000;
+  background: var(--ink);
   border: 1px solid var(--ink-light);
 }
 
@@ -651,7 +686,7 @@
   flex: 0 0 auto;
   width: 60px;
   height: 100px;
-  background: #000;
+  background: var(--ink);
   border: 2px solid transparent;
   cursor: pointer;
   opacity: 0.6;
@@ -1091,20 +1126,30 @@
 }
 
 /* Metadata editor */
+.metadata-page {
+  grid-column: 1 / -1;
+  padding-top: 0;
+  border-top: 0;
+}
+
+.metadata-page > .converter-notice {
+  margin-bottom: var(--space-xl);
+}
+
+.metadata-page > .section-header {
+  margin-bottom: var(--space-lg);
+}
+
+.metadata-page .dropzone {
+  min-height: 300px;
+  display: grid;
+  place-items: center;
+}
+
 .metadata-status {
   margin: var(--space-md) 0;
   font-style: italic;
   color: var(--ink-faded);
-}
-
-.metadata-title {
-  font-family: var(--font-serif);
-  font-size: 1.35rem;
-  font-style: italic;
-  font-weight: 400;
-  letter-spacing: 0;
-  text-transform: none;
-  color: var(--ink);
 }
 
 .metadata-editor {
@@ -1115,13 +1160,18 @@
 
 .metadata-card {
   background: var(--paper-dark);
-  border: var(--border);
+  border: var(--border-light);
+  border-top: 2px solid var(--ink);
   padding: var(--space-lg);
 }
 
 .metadata-card h3 {
-  margin-bottom: var(--space-sm);
-  font-size: 1rem;
+  margin-bottom: var(--space-md);
+  color: var(--ink-light);
+  font-size: 0.75rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
 }
 
 .metadata-actions {
@@ -1138,7 +1188,12 @@
 }
 
 .metadata-fields label strong {
-  font-size: 0.85rem;
+  display: block;
+  color: var(--ink-faded);
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
 }
 
 .metadata-fields input,
@@ -1150,6 +1205,12 @@
   border: var(--border-light);
   color: var(--ink);
   font-family: var(--font-mono);
+  font-size: 0.85rem;
+}
+
+.metadata-fields input:focus-visible,
+.metadata-chapter-row input:focus-visible {
+  border-color: var(--accent);
 }
 
 .metadata-chapter-header {
@@ -1158,6 +1219,11 @@
   align-items: center;
   gap: var(--space-sm);
   margin-bottom: var(--space-md);
+  flex-wrap: wrap;
+}
+
+.metadata-chapter-header h3 {
+  margin-bottom: 0;
 }
 
 .metadata-empty {
@@ -1186,6 +1252,9 @@
   flex: 0 0 auto;
   font-size: 0.75rem;
   font-weight: 600;
+  color: var(--ink-faded);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
 }
 
 .metadata-chapter-row .chapter-title-input {
@@ -1211,4 +1280,38 @@
 .chapter-controls .btn-delete-meta:hover {
   background: var(--accent);
   color: var(--paper);
+}
+
+@media (max-width: 600px) {
+  .result-item {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .result-actions {
+    width: 100%;
+    justify-content: flex-start;
+  }
+
+  .btn-remove-result {
+    margin-left: auto;
+  }
+
+  .metadata-card {
+    padding: var(--space-md);
+  }
+
+  .metadata-actions .btn-clear-results {
+    margin-left: 0;
+  }
+
+  .metadata-chapter-row label,
+  .metadata-chapter-row .chapter-title-input {
+    flex: 1 1 100%;
+  }
+
+  .chapter-controls {
+    width: 100%;
+    margin-left: 0;
+  }
 }

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -1,12 +1,13 @@
 :root {
   /* Paper & ink palette */
-  --paper: #fafafa;
-  --paper-dark: #f0f0f0;
-  --ink: #1a1817;
-  --ink-light: #4a4745;
-  --ink-faded: #8a8785;
-  --accent: #c23c2a;
-  --accent-hover: #a32f1f;
+  --paper: #f8f4eb;
+  --paper-dark: #ece5d8;
+  --ink: #1e1a17;
+  --ink-light: #504941;
+  --ink-faded: #746c63;
+  --accent: #b53a2b;
+  --accent-hover: #963023;
+  --success: #2f713f;
 
   /* Z-index scale */
   --z-base: 1;
@@ -35,13 +36,14 @@
 
 [data-theme="dark"] {
   color-scheme: dark;
-  --paper: #1a1817;
-  --paper-dark: #2a2725;
-  --ink: #fafafa;
-  --ink-light: #f0f0f0;
-  --ink-faded: #8a8785;
-  --accent: #ff5c4a;
-  --accent-hover: #ff7c6a;
+  --paper: #191714;
+  --paper-dark: #28241f;
+  --ink: #f7f0e5;
+  --ink-light: #d8cec0;
+  --ink-faded: #aaa094;
+  --accent: #ff715f;
+  --accent-hover: #ff917f;
+  --success: #7fc990;
 }
 
 *,
@@ -72,24 +74,28 @@ body {
   position: fixed;
   inset: 0;
   pointer-events: none;
-  opacity: 0.25;
+  opacity: 0.18;
   background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 256 256' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='noise'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.8' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23noise)'/%3E%3C/svg%3E");
   z-index: var(--z-grain);
 }
 
 /* Layout */
 .layout {
-  max-width: 900px;
+  max-width: 1024px;
   margin: 0 auto;
-  padding: var(--space-xl) var(--space-lg);
+  padding: var(--space-xl) clamp(var(--space-lg), 6vw, var(--space-2xl));
   display: grid;
   gap: var(--space-xl);
 }
 
+.layout > * {
+  min-width: 0;
+}
+
 @media (min-width: 768px) {
   .layout {
-    padding: var(--space-2xl);
-    grid-template-columns: 1fr 280px;
+    padding-block: var(--space-2xl);
+    grid-template-columns: minmax(0, 1fr) minmax(260px, 300px);
     grid-template-areas:
       "header header"
       "nav nav"
@@ -222,6 +228,14 @@ body {
   color: var(--ink);
 }
 
+@media (max-width: 767px) {
+  .nav-tabs {
+    flex-wrap: wrap;
+    justify-content: center;
+    overflow: visible;
+  }
+}
+
 .nav-tab-button {
   background: none;
   border: none;
@@ -321,7 +335,7 @@ body {
   grid-column: 1 / -1;
   padding: var(--space-sm) var(--space-md);
   background: var(--paper-dark);
-  border-left: 3px solid var(--ink-faded);
+  border-left: 3px solid var(--accent);
   margin-bottom: calc(-1 * var(--space-md));
 }
 
@@ -339,12 +353,22 @@ body {
   margin-bottom: var(--space-md);
 }
 
+.section-header h2::before {
+  content: '';
+  display: inline-block;
+  width: 1rem;
+  height: 2px;
+  margin-right: var(--space-sm);
+  vertical-align: middle;
+  background: var(--accent);
+}
+
 .section-header h2 {
   font-size: 0.75rem;
   font-weight: 700;
   text-transform: uppercase;
   letter-spacing: 0.1em;
-  color: var(--ink-faded);
+  color: var(--ink-light);
 }
 
 .badge {
@@ -355,6 +379,11 @@ body {
   color: var(--paper);
   padding: 0.15em 0.5em;
   border-radius: 2px;
+}
+
+.section-header h2.metadata-heading {
+  text-transform: none;
+  letter-spacing: 0.04em;
 }
 
 /* About page */
@@ -383,7 +412,7 @@ body {
   border-top: var(--border-light);
 }
 
-.content-section h2 {
+.content-section > h2 {
   font-family: var(--font-serif);
   font-size: 1.5rem;
   font-weight: 400;
@@ -499,4 +528,20 @@ body {
 ::selection {
   background: var(--ink);
   color: var(--paper);
+}
+
+:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    scroll-behavior: auto !important;
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+  }
 }

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -381,11 +381,6 @@ body {
   border-radius: 2px;
 }
 
-.section-header h2.metadata-heading {
-  text-transform: none;
-  letter-spacing: 0.04em;
-}
-
 /* About page */
 .about-page {
   grid-column: 1 / -1;

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -214,10 +214,12 @@ body {
 
 .nav-tab::before {
   content: '[ ';
+  transition: color 0.15s;
 }
 
 .nav-tab::after {
   content: ' ]';
+  transition: color 0.15s;
 }
 
 .nav-tab:hover {
@@ -226,6 +228,11 @@ body {
 
 .nav-tab.active {
   color: var(--ink);
+}
+
+.nav-tab.active::before,
+.nav-tab.active::after {
+  color: var(--accent);
 }
 
 @media (max-width: 767px) {
@@ -284,10 +291,12 @@ body {
 
 .nav-subtab::before {
   content: '[ ';
+  transition: color 0.15s;
 }
 
 .nav-subtab::after {
   content: ' ]';
+  transition: color 0.15s;
 }
 
 .nav-subtab:hover {
@@ -296,6 +305,11 @@ body {
 
 .nav-subtab.active {
   opacity: 1;
+}
+
+.nav-subtab.active::before,
+.nav-subtab.active::after {
+  color: var(--accent);
 }
 
 /* Soon placeholder */

--- a/src/styles/manga-search.css
+++ b/src/styles/manga-search.css
@@ -18,7 +18,7 @@
   border: var(--border);
   display: flex;
   flex-direction: column;
-  box-shadow: 6px 6px 0 var(--ink);
+  box-shadow: 4px 4px 0 var(--ink);
 }
 
 .manga-search-header {
@@ -79,7 +79,7 @@
   font-size: 1.2rem;
   cursor: pointer;
   color: var(--ink);
-  transition: all 0.15s;
+  transition: background-color 0.15s, color 0.15s, border-color 0.15s;
 }
 
 .manga-search-close:hover {
@@ -105,8 +105,8 @@
   outline: none;
 }
 
-.manga-search-input:focus {
-  outline: 2px solid var(--ink);
+.manga-search-input:focus-visible {
+  outline: 2px solid var(--accent);
   outline-offset: 1px;
 }
 
@@ -165,7 +165,8 @@
   border-bottom: none;
 }
 
-.manga-search-item:hover {
+.manga-search-item:hover,
+.manga-search-item:focus-visible {
   background: var(--paper-dark);
 }
 
@@ -194,7 +195,7 @@
 }
 
 .manga-search-seed {
-  color: #2a7f2a;
+  color: var(--success);
 }
 
 .manga-search-leech {
@@ -215,7 +216,7 @@
   text-decoration: none;
   padding: 2px var(--space-sm);
   border: var(--border-light);
-  transition: all 0.15s;
+  transition: background-color 0.15s, color 0.15s, border-color 0.15s;
 }
 
 .manga-search-magnet:hover {
@@ -242,7 +243,7 @@
   border: var(--border-light);
   color: var(--ink);
   cursor: pointer;
-  transition: all 0.15s;
+  transition: background-color 0.15s, color 0.15s, border-color 0.15s;
 }
 
 .manga-search-trigger:hover {
@@ -269,7 +270,7 @@
   border: var(--border-light);
   color: var(--ink);
   cursor: pointer;
-  transition: all 0.15s;
+  transition: background-color 0.15s, color 0.15s, border-color 0.15s;
 }
 
 .theme-toggle:hover {
@@ -281,4 +282,24 @@
 .theme-toggle svg {
   width: 16px;
   height: 16px;
+}
+
+@media (max-width: 600px) {
+  .manga-search-overlay {
+    padding: var(--space-md);
+  }
+
+  .manga-search-modal {
+    width: 100%;
+    max-height: calc(100dvh - 2 * var(--space-md));
+  }
+
+  .manga-search-header,
+  .manga-search-input-wrap {
+    padding-inline: var(--space-md);
+  }
+
+  .manga-search-results {
+    padding-inline: var(--space-md);
+  }
 }


### PR DESCRIPTION
Hi! This PR brings together the interface changes we have been testing locally. The idea was not to change the identity of XTC.js, but to keep the same paper-like style and make it cleaner, easier to understand and nicer to use in both light and dark mode. The active section is now easier to see, the layouts behave better on smaller screens, and Metadata finally follows the same style as the rest of the Extra tools.

I also added a small X to every finished conversion, so if you are working with several files you can remove only one result instead of having to clear everything. That result is also removed from the browser storage, so it will not appear again after refreshing.

For PDFs, there is now a `Two-column paper (4 pages)` option under Portrait mode. This is meant for papers with two columns: it creates four readable pages in the correct order while keeping the text upright. It only appears in Portrait to avoid filling the landscape settings with an option that does not belong there, but we can implement that one if requested.

The device selector now says `X4 / Pro` for the shared 480x800 target and keeps X3 available separately. I removed the X3 warning, shortened the 2-bit label and marked XTCH as experimental while we continue testing it.

I kept the visual changes light and reused what was already in the project, so this does not add a heavy UI library or anything that should make conversion harder for lower-end devices.

I have tested all this locally. `bun test` passes all 14 tests, and `bun run build` also completes correctly.

Thanks! If anything in the visual part still feels weird, or does not work as expected, let us know so we can change it!
