### PR TITLE
fix: reload PWA after service worker updates

### DIFF
--- a/scripts/pwa-update.test.ts
+++ b/scripts/pwa-update.test.ts
@@ -1,0 +1,29 @@
+import { expect, test } from 'bun:test'
+import { mkdtemp, readFile, readdir, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join, resolve } from 'node:path'
+import { build } from 'vite'
+
+test('production builds reload open clients after a service worker update', async () => {
+  const outDir = await mkdtemp(join(tmpdir(), 'xtcjs-pwa-'))
+
+  try {
+    await build({
+      configFile: resolve(import.meta.dir, '../vite.config.ts'),
+      build: { outDir, emptyOutDir: true },
+      logLevel: 'silent',
+    })
+
+    const indexHtml = await readFile(join(outDir, 'index.html'), 'utf8')
+    const scripts = (await readdir(join(outDir, 'assets'))).filter((file) => file.endsWith('.js'))
+    const bundles = await Promise.all(scripts.map((file) => readFile(join(outDir, 'assets', file), 'utf8')))
+
+    expect(indexHtml).not.toContain('/registerSW.js')
+    expect(bundles.some((bundle) => (
+      bundle.includes('new Workbox("/sw.js"') ||
+      /new \w+\("\/sw\.js".*addEventListener\("activated".*location\.reload\(\)/s.test(bundle)
+    ))).toBe(true)
+  } finally {
+    await rm(outDir, { recursive: true, force: true })
+  }
+}, 30_000)

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,11 +1,14 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import { RouterProvider, createRouter } from '@tanstack/react-router'
+import { registerSW } from 'virtual:pwa-register'
 import { routeTree } from './routeTree.gen'
 
 import './styles/main.css'
 import './styles/components.css'
 import './styles/animations.css'
+
+registerSW()
 
 const router = createRouter({ routeTree })
 

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,1 +1,2 @@
 /// <reference types="vite/client" />
+/// <reference types="vite-plugin-pwa/vanillajs" />


### PR DESCRIPTION
The website was deploying the new files correctly, but some browsers could stay on the previous interface because the PWA service worker updated without reloading the page that was already open.

This changes the registration to the update-aware helper already provided by `vite-plugin-pwa`. When a new worker activates, the open page reloads and starts using the new assets. I kept the existing offline cache and Cloudflare configuration untouched.

People who are still running the old service worker may need one final close/reopen or second refresh when this first reaches them. Once this version has loaded, later updates should switch automatically.

I also added a production-build regression test to make sure we do not return to the passive registration path.

### Tested

- `bun test` - 15 passing
- `bun run build:static`
- Local Chromium upgrade from production build A to build B, confirming an automatic reload and the new entry asset
